### PR TITLE
feat(tools): add can_tester PC-side debugging tool

### DIFF
--- a/STM32LowLevel/CMakeLists.txt
+++ b/STM32LowLevel/CMakeLists.txt
@@ -94,7 +94,7 @@ target_include_directories(can_lib PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/Drivers/CMSIS/Device/ST/STM32G4xx/Include
     ${CMAKE_CURRENT_SOURCE_DIR}/Drivers/CMSIS/Include
 )
-target_link_libraries(can_lib PUBLIC stm32cubemx)
+target_link_libraries(can_lib PUBLIC stm32cubemx debug_lib)
 
 # Add include paths
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE

--- a/STM32LowLevel/Core/Src/main.cpp
+++ b/STM32LowLevel/Core/Src/main.cpp
@@ -1092,10 +1092,25 @@ static void sendFeedback(void)
 
 #ifdef MODC_IMU
     imu.update();
+// MK2_MOD3 has IMU rotated 90 deg, so roll/pitch are swapped and negative
+#if MODULE_DEFINE == MK2_MOD3
+    float imuRoll = -imu.getRoll();
+    float imuPitch = -imu.getPitch();
+    canW.sendMessage(JOINT_ROLL_FEEDBACK, &imuPitch, 4U);
+    canW.sendMessage(JOINT_PITCH_FEEDBACK, &imuRoll, 4U);
+// MK2_MOD1 has IMU flipped 180 deg, so pitch is negative
+#elif MODULE_DEFINE == MK2_MOD1
+    float imuRoll = imu.getRoll();
+    float imuPitch = -imu.getPitch();
+    canW.sendMessage(JOINT_ROLL_FEEDBACK, &imuRoll, 4U);
+    canW.sendMessage(JOINT_PITCH_FEEDBACK, &imuPitch, 4U);
+// MK2_MOD2 has IMU in standard orientation, so direct mapping
+#elif MODULE_DEFINE == MK2_MOD2
     float imuRoll = imu.getRoll();
     float imuPitch = imu.getPitch();
     canW.sendMessage(JOINT_ROLL_FEEDBACK, &imuRoll, 4U);
     canW.sendMessage(JOINT_PITCH_FEEDBACK, &imuPitch, 4U);
+#endif
     LOG_DEBUG("[IMU] Roll: %.2f deg, Pitch: %.2f deg\n", imuRoll, imuPitch);
 #endif // MODC_IMU
 

--- a/STM32LowLevel/Core/Src/main.cpp
+++ b/STM32LowLevel/Core/Src/main.cpp
@@ -346,6 +346,11 @@ extern "C" int main(void)
         {}
     }
 
+    // Critical delay for Dynamixel motor power-up stabilization
+    // This is needed for normal power-on to ensure
+    // motors are ready for initialization commands
+    HAL_Delay(200);
+
     // Debug — must be first so all subsequent prints reach USB CDC
 #ifdef DEBUG
     debug.setLevel(Level::LogDebug);
@@ -615,14 +620,17 @@ static void dxlTractionInit(void)
     // Disable torque first for safe reconfiguration
     motLeft.setTorqueEnable(false);
     motRight.setTorqueEnable(false);
+    HAL_Delay(10U);
 
     // Status return level 2 — respond to all instructions
     motLeft.setStatusReturnLevel(2U);
     motRight.setStatusReturnLevel(2U);
+    HAL_Delay(10U);
 
     // Drive mode: right motor needs reverseMode=true (opposite mounting)
     motLeft.setDriveMode(false, false, false);
     motRight.setDriveMode(false, false, true);
+    HAL_Delay(10U);
 
     // Operating mode 1 = velocity control
     dxlTraction.enableSync(tractionIds, n);
@@ -630,6 +638,7 @@ static void dxlTractionInit(void)
 
     // Instant velocity response (profile acceleration = 0)
     dxlTraction.setProfileAcceleration(0U);
+    HAL_Delay(10U);
 
     // Enable torque
     motLeft.setTorqueEnable(true);
@@ -1107,6 +1116,18 @@ static void sendFeedback(void)
     float joint_posf_2_rad = (float)(jointPosf2 - jointPos0Mot2) * DXL_TO_RAD;
     canW.sendMessage(JOINT_ROLL_2_FEEDBACK, &joint_posf_2_rad, 4U);
 #endif // MODC_JOINT
+
+    // Battery voltage — all modules, low frequency (0.2 Hz)
+    {
+        static uint32_t lastBatCan = 0U;
+        uint32_t now = HAL_GetTick();
+        if (now - lastBatCan >= DT_BAT_CAN)
+        {
+            lastBatCan = now;
+            float vbat = battery.readVoltage();
+            canW.sendMessage(BATTERY_VOLTAGE, &vbat, 4U);
+        }
+    }
 }
 
 /**
@@ -1329,6 +1350,33 @@ static void handleSetpoint(uint8_t msgId, const uint8_t* msgData)
             dxlTractionInit();
             LOG_INFO("[CAN] MOTOR_TRACTION_REBOOT: traction motors rebooted\n");
             break;
+
+        // Torque enable/disable — all modules
+        case TORQUE_ENABLE_DISABLE:
+        {
+            uint16_t torqueBits;
+            memcpy(&torqueBits, msgData, 2U);
+            // Bit 0 = right traction, bit 1 = left traction
+            motRight.setTorqueEnable((torqueBits & 0x0001U) != 0U);
+            motLeft.setTorqueEnable((torqueBits & 0x0002U) != 0U);
+#ifdef MODC_ARM
+            // Bits 2-7 = arm motors J1a, J1b, J2, J3, J4, J5 (J6 beak excluded)
+            armMot1a.setTorqueEnable((torqueBits & 0x0004U) != 0U);
+            armMot1b.setTorqueEnable((torqueBits & 0x0008U) != 0U);
+            armMot2.setTorqueEnable((torqueBits & 0x0010U) != 0U);
+            armMot3.setTorqueEnable((torqueBits & 0x0020U) != 0U);
+            armMot4.setTorqueEnable((torqueBits & 0x0040U) != 0U);
+            armMot5.setTorqueEnable((torqueBits & 0x0080U) != 0U);
+#endif
+#ifdef MODC_JOINT
+            // Bits 2-4 = joint motors J1-left, J1-right, J2
+            jointMot1L.setTorqueEnable((torqueBits & 0x0004U) != 0U);
+            jointMot1R.setTorqueEnable((torqueBits & 0x0008U) != 0U);
+            jointMot2.setTorqueEnable((torqueBits & 0x0010U) != 0U);
+#endif
+            LOG_INFO("[CAN] TORQUE_ENABLE_DISABLE: 0x%04X\n", torqueBits);
+            break;
+        }
 
         default:
             LOG_DEBUG("[CAN] Unknown msg_id: 0x%02X\n", msgId);

--- a/STM32LowLevel/Inc/communication.h
+++ b/STM32LowLevel/Inc/communication.h
@@ -61,6 +61,7 @@
 #define MOTOR_TRACTION_REBOOT       0x71  ///< Reboot traction motors           (no payload)
 #define MOTOR_TRACTION_ERROR_STATUS 0x72  ///< Traction HW error bytes — uint8[2]: right, left
 #define MOTOR_ARM_ERROR_STATUS      0x73  ///< Arm HW error bytes     — uint8[7]: J1a…J6
+#define TORQUE_ENABLE_DISABLE       0x74  ///< Per-motor torque enable/disable  — uint16 bitfield (1=enable, 0=disable per bit)
 
 // Arm velocity feedback — MK2 MOD1 only (0x8X)
 #define ARM_PITCH_1a1b_FEEDBACK_VEL 0x80  ///< Arm J1a/J1b velocity — Float×2, rad/s

--- a/STM32LowLevel/Inc/definitions.h
+++ b/STM32LowLevel/Inc/definitions.h
@@ -15,6 +15,7 @@
 
 // Main loop timings (ms)
 #define DT_BAT        1000U  ///< Battery & health check interval:  1 Hz
+#define DT_BAT_CAN    5000U  ///< Battery voltage CAN TX interval: 0.2 Hz (every 5 s)
 #define DT_TEL          40U  ///< CAN telemetry (sendFeedback) interval: 25 Hz
 #define DT_DXL_CHECK  1000U  ///< Dynamixel error-status poll interval:  1 Hz
 

--- a/STM32LowLevel/Lib/CanWrapper/CanWrapper.cpp
+++ b/STM32LowLevel/Lib/CanWrapper/CanWrapper.cpp
@@ -43,7 +43,8 @@ void CanWrapper::begin()
 bool CanWrapper::sendMessage(uint8_t msgType, const void* data, uint8_t length)
 {
     // Check TX FIFO not full (FDCAN_TXFQS.TFQF)
-    if (FDCAN2->TXFQS & FDCAN_TXFQS_TFQF) {
+    if (FDCAN2->TXFQS & FDCAN_TXFQS_TFQF)
+    {
         LOG_WARN("CAN: TX FIFO full\n");
         return false;
     }
@@ -112,7 +113,7 @@ bool CanWrapper::readMessage(uint8_t* msgType, uint8_t* data)
 
     // Acknowledge RX FIFO0 (increment get index)
     FDCAN2->RXF0A = getIdx;
-    
+
     LOG_DEBUG("CAN RX: type=0x%02X len=%u\n", *msgType, dlc);
 
     return true;

--- a/STM32LowLevel/Lib/CanWrapper/CanWrapper.cpp
+++ b/STM32LowLevel/Lib/CanWrapper/CanWrapper.cpp
@@ -8,6 +8,7 @@
 #include "fdcan.h"
 #include "main.h"
 #include "mod_config.h"
+#include "Debug.h"
 
 // TX FIFO element size in bytes: 2 header words + 2 data words (8 bytes) = 16 bytes
 // For classic 8-byte CAN frames, the TX element is 4 words × 4 bytes = 16 bytes.
@@ -42,8 +43,10 @@ void CanWrapper::begin()
 bool CanWrapper::sendMessage(uint8_t msgType, const void* data, uint8_t length)
 {
     // Check TX FIFO not full (FDCAN_TXFQS.TFQF)
-    if (FDCAN2->TXFQS & FDCAN_TXFQS_TFQF)
+    if (FDCAN2->TXFQS & FDCAN_TXFQS_TFQF) {
+        LOG_WARN("CAN: TX FIFO full\n");
         return false;
+    }
 
     // Get TX FIFO put index (FDCAN_TXFQS.TFQPI bits[17:16])
     uint32_t putIdx = (FDCAN2->TXFQS & FDCAN_TXFQS_TFQPI_Msk) >> FDCAN_TXFQS_TFQPI_Pos;
@@ -109,6 +112,8 @@ bool CanWrapper::readMessage(uint8_t* msgType, uint8_t* data)
 
     // Acknowledge RX FIFO0 (increment get index)
     FDCAN2->RXF0A = getIdx;
+    
+    LOG_DEBUG("CAN RX: type=0x%02X len=%u\n", *msgType, dlc);
 
     return true;
 }

--- a/STM32LowLevel/Lib/DynamixelLL/DynamixelLL.cpp
+++ b/STM32LowLevel/Lib/DynamixelLL/DynamixelLL.cpp
@@ -284,7 +284,7 @@ uint8_t DynamixelLL::setGoalVelocityRpm(float rpm)
     if (rpm < -maxRPM)
         rpm = -maxRPM;
     int16_t val = (int16_t)(rpm / 0.229f);
-    return writeRegister(104u, (uint32_t)(uint16_t)val, 4u);
+    return writeRegister(104u, (uint32_t)val, 4u);
 }
 
 uint8_t DynamixelLL::getPresentVelocityRpm(float& rpm)

--- a/STM32LowLevel/Lib/DynamixelLL/DynamixelLL.tpp
+++ b/STM32LowLevel/Lib/DynamixelLL/DynamixelLL.tpp
@@ -376,7 +376,7 @@ uint8_t DynamixelLL::setGoalVelocityRpm(const float (&rpmValues)[N])
             rpm = maxRPM;
         if (rpm < -maxRPM)
             rpm = -maxRPM;
-        processed[i] = static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(rpm / 0.229f)));
+        processed[i] = static_cast<uint32_t>(static_cast<int16_t>(rpm / 0.229f));
     }
     return syncWrite(104, 4, _motorIDs, processed, _numMotors) ? 0u : 1u;
 }

--- a/tools/can_tester/README.md
+++ b/tools/can_tester/README.md
@@ -128,6 +128,11 @@ python -m tools.can_tester.web_dashboard --demo
 
 # Custom port
 python -m tools.can_tester.web_dashboard -i gs_usb -c 0 -p 9000
+
+# Debug mode — print received CAN messages to terminal
+# Useful when the dashboard display isn't working, to verify the backend
+# is receiving messages from the adapter:
+python -m tools.can_tester.web_dashboard -i gs_usb -c 0 --debug
 ```
 
 Open `http://localhost:8080` in a browser. Features:
@@ -139,6 +144,11 @@ Open `http://localhost:8080` in a browser. Features:
 - Command descriptions with value ranges
 - Emergency stop button
 - Collapsible message statistics
+
+**Debugging:** If the dashboard shows no messages, use `--debug` to print received
+CAN messages to the terminal. You can also check `http://localhost:8080/status`
+to see the last received message. This helps distinguish between hardware issues
+(backend receives nothing) and display issues (backend receives but browser doesn't show).
 
 ### Interactive CLI
 

--- a/tools/can_tester/README.md
+++ b/tools/can_tester/README.md
@@ -1,0 +1,232 @@
+# CAN Bus Testing Tool
+
+PC-side CAN bus testing and debugging tool for the STM32LowLevel firmware.
+Provides both an **interactive CLI** and a **web dashboard** for sending
+commands and monitoring CAN bus traffic in real time.
+
+## Hardware
+
+- **USB2CAN adapter**: Innomaker USB2CAN MS124 ([Part-DB #233](https://part-db.teamisaac.it/en/part/233/info))
+- **Driver**: `gs_usb` — uses the WinUSB class driver on Windows, native kernel driver on Linux
+- **Bitrate**: 1 Mbit/s arbitration / 2 Mbit/s data (CAN FD with BRS, Extended 29-bit identifiers)
+
+## Prerequisites
+
+- Python ≥ 3.10
+- The USB2CAN adapter plugged in via USB
+- CAN bus wiring between the adapter and at least one STM32 module
+
+## Installation
+
+```bash
+cd STM32LowLevel
+pip install -r tools/can_tester/requirements.txt
+```
+
+> All commands below assume the working directory is `STM32LowLevel/` and
+> `PYTHONPATH` includes `.` (or you use `python -m` from that directory).
+
+---
+
+## Platform Setup
+
+### Linux (SocketCAN)
+
+The `gs_usb` kernel module is loaded automatically when you plug in the adapter.
+
+```bash
+# Verify the device is detected
+dmesg | grep gs_usb
+
+# Bring up the CAN FD interface at 1 Mbit/s arbitration + 2 Mbit/s data
+sudo ip link set can0 up type can bitrate 1000000 dbitrate 2000000 fd on
+
+# Verify
+ip -details link show can0
+```
+
+### Windows (WinUSB)
+
+If you have issues with the version of the driver that Windows automatically installs, you can manually switch to the WinUSB driver:
+
+1. Plug in the USB2CAN adapter.
+2. Open **Device Manager** → find the device under *Universal Serial Bus devices* or *Other devices*
+   (it may appear as "USB2CAN" or "CAN").
+3. Right-click → **Update driver** → **Browse my computer for drivers**
+   → **Let me pick from a list** → select **Universal Serial Bus devices**
+   → choose **WinUSB Device**
+4. No additional driver download is needed — the `gs_usb` Python package
+   talks to WinUSB directly via `pyusb` / `libusb`.
+
+> **Reference**: The [Innomaker USB2CAN GitHub repo](https://github.com/INNO-MAKER/usb2can)
+> has the official user manual, Windows software, and firmware notes.
+
+#### Windows ARM64 Quirk
+
+The standard `libusb` wheel ships only x64 binaries.
+On ARM64 Windows you must build `libusb` from source:
+
+1. **Install Visual Studio 2022 or newer** with the *ARM64* build tools
+   (C++ Desktop workload + ARM64 component).
+
+2. **Add `msbuild` to your PATH** if it's not already available in your terminal:
+   ```
+   C:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin
+   ```
+   Make sure to confirm the exact path on your system, as it may vary based on the Visual Studio version and edition. Run to confirm:
+   ```powershell
+   msbuild --version
+   ```
+
+3. **Clone and build libusb**:
+   ```powershell
+   # Running from the root of your disk (e.g. C:\)
+   git clone https://github.com/libusb/libusb.git
+   cd libusb
+   cd msvc
+   # Open the VS solution and build the ARM64-Release target, or:
+   msbuild libusb_dll.vcxproj /p:Configuration=Release /p:Platform=ARM64 
+   ```
+
+4. **Copy the DLL** next to your Python interpreter:
+   ```powershell
+   # Adjust Python path as needed for your Python version and installation location
+   copy C:\libusb\build\v145\ARM64\Release\dll\libusb-1.0.dll "$env:LOCALAPPDATA\Programs\Python\Python313-arm64\" 
+   ```
+   If you are using `uv` or you want to keep everything local in your `venv`, run this instead:
+   ```powershell
+   # Adjust the path to your virtual environment's directory
+   copy C:\libusb\build\v145\ARM64\Release\dll\libusb-1.0.dll "{path-to-your-venv}"
+   ```
+   If you want to make the DLL available system-wide in case you still have issues locating the dll in your environment, you can copy it to System32:
+   ```powershell
+   # Use with caution — It may cause potential conflicts with your existing libraries and require admin permissions
+   copy C:\libusb\build\v145\ARM64\Release\dll\libusb-1.0.dll "C:\Windows\System32"
+   ```
+
+5. The CAN tester's `__init__.py` automatically detects ARM64 Windows and
+   patches `pyusb` to load `libusb-1.0.dll` from that location — no
+   manual environment variables needed.
+
+6. Then follow the same WinUSB driver steps described in the **Windows (WinUSB)** upper setup section above.
+
+---
+
+## Usage
+
+### Web Dashboard
+
+```bash
+# Start with USB2CAN adapter (gs_usb)
+python -m tools.can_tester.web_dashboard -i gs_usb -c 0 --port 8080
+
+# Start with SocketCAN (Linux)
+python -m tools.can_tester.web_dashboard -i socketcan -c can0
+
+# Demo mode — no hardware required (virtual bus)
+python -m tools.can_tester.web_dashboard --demo
+
+# Custom port
+python -m tools.can_tester.web_dashboard -i gs_usb -c 0 -p 9000
+```
+
+Open `http://localhost:8080` in a browser. Features:
+
+- Real-time message feed via SSE (auto-reconnecting)
+- Filter by subsystem (arm, traction, joint, feedback)
+- Module-aware command panel — shows arm commands for MOD1, joint commands for MOD2/MOD3
+- Target module selector with CAN address display
+- Command descriptions with value ranges
+- Emergency stop button
+- Collapsible message statistics
+
+### Interactive CLI
+
+```bash
+# Linux (SocketCAN)
+python -m tools.can_tester -i socketcan -c can0
+
+# Windows / Linux (gs_usb)
+python -m tools.can_tester -i gs_usb -c 0
+
+# Target a specific module
+python -m tools.can_tester -i gs_usb -c 0 -m MK2_MOD2
+```
+
+#### CLI Commands
+
+| Command | Description |
+|---------|-------------|
+| `send traction <left> <right>` | Set traction motor speeds (RPM) |
+| `send arm_j2 <angle>` | Set arm elbow pitch (radians) |
+| `send arm_j3 <angle>` | Set arm roll J3 (radians) |
+| `send arm_j4 <angle>` | Set arm wrist pitch (radians) |
+| `send arm_j5 <angle>` | Set arm wrist roll (radians) |
+| `send arm_1a1b <θ> <φ>` | Set arm J1 differential (radians) |
+| `send beak open\|close` | Control beak gripper |
+| `send reset_arm` | Move arm to home position |
+| `send reboot_arm` | Reboot arm Dynamixel motors |
+| `send reboot_traction` | Reboot traction motors |
+| `stop` | Emergency stop all motors |
+| `monitor [filter]` | Start live monitoring (filters: `all`, `arm`, `traction`, `joint`, `feedback`) |
+| `test <name>` | Run a test sequence (see `procedure.md`) |
+| `status` | Show message statistics |
+
+#### Test Sequences
+
+| Name | Description |
+|------|-------------|
+| `traction` | Forward → stop → reverse → stop |
+| `traction_diff` | Turn left → turn right → spin |
+| `arm_init` | Reset arm to home position |
+| `arm_joints` | Move each arm joint individually |
+| `arm_beak` | Beak open/close cycle |
+| `arm_reboot` | Reboot and re-initialize arm motors |
+| `full` | Complete diagnostic sequence |
+
+---
+
+## Architecture
+
+```
+can_tester/
+├── __init__.py          # ARM64 Windows libusb workaround
+├── __main__.py          # CLI entry point
+├── protocol.py          # CAN ID / MsgType definitions (synced with communication.h)
+├── header_parser.py     # C preprocessor for communication.h / mod_config.h validation
+├── codec.py             # Payload encode/decode (struct-based)
+├── sender.py            # High-level message sender
+├── monitor.py           # Real-time bus monitor with named filters
+├── cli.py               # Interactive REPL
+├── web_dashboard.py     # Flask web UI with SSE
+├── test_sequences.py    # Pre-built test routines
+├── test_dry.py          # Offline validation tests
+├── requirements.txt     # Python dependencies
+├── procedure.md         # Testing procedures and checklists
+└── README.md            # This file
+```
+
+## CAN Protocol
+
+See the [CAN bus protocol documentation](https://docs.teamisaac.it/doc/can-bus-protocol-t40e2NOEqp)
+for the full message ID table.
+
+Extended CAN identifiers (29-bit) are encoded as:
+- **Byte 0** `[0:7]`: Source address (sender module ID)
+- **Byte 1** `[8:15]`: Destination address
+- **Byte 2** `[16:23]`: Message type (PDU Format)
+
+| Address | Module | Subsystems |
+|---------|--------|------------|
+| `0x00`  | Central (Jetson / PC) | — |
+| `0x21`  | MK2_MOD1 — Head | Traction + Robotic Arm (6-DOF + beak) |
+| `0x22`  | MK2_MOD2 — Body | Traction + Inter-module Joint |
+| `0x23`  | MK2_MOD3 — Tail | Traction + Inter-module Joint |
+
+## References
+
+- [CAN bus protocol](https://docs.teamisaac.it/doc/can-bus-protocol-t40e2NOEqp)
+- [STM32LowLevel firmware](https://github.com/Team-Isaac-Polito/STM32LowLevel)
+- [Innomaker USB2CAN repo](https://github.com/INNO-MAKER/usb2can) — user manual, Windows software, firmware
+- [python-can documentation](https://python-can.readthedocs.io/)
+- [Part-DB entry for USB2CAN MS124](https://part-db.teamisaac.it/en/part/233/info)

--- a/tools/can_tester/__init__.py
+++ b/tools/can_tester/__init__.py
@@ -1,0 +1,45 @@
+# STM32LowLevel CAN bus testing toolkit
+
+# ── Ensure libusb backend is available on ARM64 Windows ──────────────────────
+# pyusb's auto-discovery doesn't find libusb-1.0.dll on ARM64 Windows.
+# If the DLL exists next to the Python interpreter (or the base interpreter
+# when running inside a venv), monkey-patch gs_usb to use it.
+# This is a no-op on Linux or if the backend is already found.
+import sys as _sys
+import os as _os
+import platform as _platform
+
+if _platform.system() == "Windows" and _platform.machine() == "ARM64":
+    # Check both venv prefix and base prefix (global install)
+    _candidate_dirs = list(dict.fromkeys([_sys.prefix, _sys.base_prefix]))
+    _dll_path = None
+    for _d in _candidate_dirs:
+        _p = _os.path.join(_d, "libusb-1.0.dll")
+        if _os.path.isfile(_p):
+            _dll_path = _p
+            break
+
+    if _dll_path:
+        try:
+            import usb.backend.libusb1 as _libusb1
+            _backend = _libusb1.get_backend(find_library=lambda _x: _dll_path)
+            if _backend is not None:
+                # Patch gs_usb.gs_usb to use our backend
+                import gs_usb.gs_usb as _gs
+                _orig_scan = _gs.GsUsb.scan
+
+                @classmethod
+                def _patched_scan(cls):
+                    import usb.core
+                    devs = []
+                    for dev in usb.core.find(
+                        find_all=True,
+                        custom_match=cls.is_gs_usb_device,
+                        backend=_backend,
+                    ):
+                        devs.append(cls(dev))
+                    return devs
+
+                _gs.GsUsb.scan = _patched_scan
+        except ImportError:
+            pass

--- a/tools/can_tester/__main__.py
+++ b/tools/can_tester/__main__.py
@@ -1,0 +1,4 @@
+"""Allow running as `python -m tools.can_tester`."""
+from .cli import main
+
+main()

--- a/tools/can_tester/cli.py
+++ b/tools/can_tester/cli.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""
+Interactive CLI for STM32LowLevel CAN bus testing.
+
+Usage:
+    python -m tools.can_tester --interface socketcan --channel can0
+    python -m tools.can_tester --interface gs_usb --channel 0   # Innomaker USB2CAN on Windows/Linux
+    python -m tools.can_tester --interface slcan --channel COM3  # Serial CAN adapter
+
+Commands:
+    send traction <left_rpm> <right_rpm>    Set traction motor speeds
+    send arm_j2 <angle_rad>                 Set arm elbow pitch
+    send arm_j3 <angle_rad>                 Set arm roll J3
+    send arm_j4 <angle_rad>                 Set arm wrist pitch
+    send arm_j5 <angle_rad>                 Set arm wrist roll
+    send arm_1a1b <theta> <phi>             Set arm differential J1
+    send beak open|close                    Control beak gripper
+    send reset_arm                          Move arm to home position
+    send set_home [permanent]               Set current position as home (default: interim)
+    send reboot_arm                         Reboot arm motors
+    send reboot_traction                    Reboot traction motors
+    stop                                    Emergency stop all motors
+    monitor [filter]                        Start monitoring (filter: all|arm|traction|joint|feedback)
+    test <name>                             Run test sequence (traction|arm_init|arm_joints|arm_beak|full)
+    status                                  Show monitor statistics
+    help                                    Show this help
+    quit                                    Exit
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import threading
+import time
+from typing import Optional
+
+import can
+
+from .protocol import ModuleAddress
+from .sender import CanSender
+from .monitor import CanMonitor, NAMED_FILTERS
+from .test_sequences import TESTS
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="STM32LowLevel CAN bus testing CLI",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--interface", "-i",
+        default="gs_usb",
+        help="python-can interface type (default: gs_usb)",
+    )
+    parser.add_argument(
+        "--channel", "-c",
+        default="0",
+        help="CAN channel (default: 0)",
+    )
+    parser.add_argument(
+        "--bitrate", "-b",
+        type=int,
+        default=1000000,
+        help="CAN arbitration bitrate in bps (default: 1000000 = 1 Mbit/s)",
+    )
+    parser.add_argument(
+        "--data-bitrate", "-D",
+        type=int,
+        default=2000000,
+        help="CAN FD data-phase bitrate in bps (default: 2000000 = 2 Mbit/s)",
+    )
+    parser.add_argument(
+        "--module", "-m",
+        default="MK2_MOD1",
+        choices=["MK2_MOD1", "MK2_MOD2", "MK2_MOD3"],
+        help="Target module (default: MK2_MOD1)",
+    )
+    return parser.parse_args()
+
+
+class CLI:
+    """Interactive command-line interface for CAN testing."""
+
+    def __init__(self, bus: can.BusABC, target: int):
+        self.bus = bus
+        self.sender = CanSender(bus)
+        self.monitor = CanMonitor(bus)
+        self.target = target
+        self._monitor_thread: Optional[threading.Thread] = None
+
+    def run(self) -> None:
+        """Main REPL loop."""
+        print("STM32LowLevel CAN Tester — type 'help' for commands")
+        print(f"Target module: {ModuleAddress(self.target).name}")
+        print()
+
+        while True:
+            try:
+                line = input("can> ").strip()
+            except (EOFError, KeyboardInterrupt):
+                print("\nExiting...")
+                break
+
+            if not line:
+                continue
+
+            parts = line.split()
+            cmd = parts[0].lower()
+
+            try:
+                if cmd == "quit" or cmd == "exit" or cmd == "q":
+                    break
+                elif cmd == "help" or cmd == "?":
+                    self._help()
+                elif cmd == "send":
+                    self._handle_send(parts[1:])
+                elif cmd == "stop":
+                    self.sender.stop_all()
+                    print("Emergency stop sent to all modules.")
+                elif cmd == "monitor":
+                    self._handle_monitor(parts[1:])
+                elif cmd == "test":
+                    self._handle_test(parts[1:])
+                elif cmd == "status":
+                    self._show_status()
+                else:
+                    print(f"Unknown command: '{cmd}'. Type 'help' for commands.")
+            except Exception as e:
+                print(f"Error: {e}")
+
+        self.monitor.stop()
+
+    def _help(self) -> None:
+        print(__doc__)
+
+    def _handle_send(self, args: list[str]) -> None:
+        if not args:
+            print("Usage: send <command> [args...]")
+            return
+
+        subcmd = args[0].lower()
+
+        if subcmd == "traction" and len(args) == 3:
+            left, right = float(args[1]), float(args[2])
+            self.sender.traction(left, right, self.target)
+            print(f"Traction: left={left} RPM, right={right} RPM")
+
+        elif subcmd == "arm_1a1b" and len(args) == 3:
+            theta, phi = float(args[1]), float(args[2])
+            self.sender.arm_pitch_1a1b(theta, phi)
+            print(f"Arm J1 differential: θ={theta}, φ={phi} rad")
+
+        elif subcmd == "arm_j2" and len(args) == 2:
+            angle = float(args[1])
+            self.sender.arm_pitch_j2(angle)
+            print(f"Arm J2 pitch: {angle} rad")
+
+        elif subcmd == "arm_j3" and len(args) == 2:
+            angle = float(args[1])
+            self.sender.arm_roll_j3(angle)
+            print(f"Arm J3 roll: {angle} rad")
+
+        elif subcmd == "arm_j4" and len(args) == 2:
+            angle = float(args[1])
+            self.sender.arm_pitch_j4(angle)
+            print(f"Arm J4 pitch: {angle} rad")
+
+        elif subcmd == "arm_j5" and len(args) == 2:
+            angle = float(args[1])
+            self.sender.arm_roll_j5(angle)
+            print(f"Arm J5 roll: {angle} rad")
+
+        elif subcmd == "beak":
+            if len(args) < 2:
+                print("Usage: send beak open|close")
+                return
+            close = args[1].lower() in ("close", "1", "true")
+            self.sender.arm_beak(close=close)
+            print(f"Beak: {'close' if close else 'open'}")
+
+        elif subcmd == "reset_arm":
+            self.sender.reset_arm()
+            print("Reset arm to home position.")
+
+        elif subcmd == "set_home":
+            persist = len(args) > 1 and args[1] == "permanent"
+            self.sender.set_home(persist=persist)
+            mode = "permanent (flash)" if persist else "interim (session)"
+            print(f"Set home: {mode}")
+
+        elif subcmd == "reboot_arm":
+            self.sender.reboot_arm()
+            print("Rebooting arm motors...")
+
+        elif subcmd == "reboot_traction":
+            self.sender.reboot_traction(self.target)
+            print("Rebooting traction motors...")
+
+        elif subcmd == "joint_1a1b" and len(args) == 3:
+            theta, phi = float(args[1]), float(args[2])
+            self.sender.joint_pitch_1a1b(theta, phi, self.target)
+            print(f"Joint differential: θ={theta}, φ={phi} rad")
+
+        elif subcmd == "joint_roll" and len(args) == 2:
+            angle = float(args[1])
+            self.sender.joint_roll(angle, self.target)
+            print(f"Joint roll: {angle} rad")
+
+        else:
+            print(f"Unknown send command: '{subcmd}' with {len(args) - 1} args")
+            print("Available: traction, arm_1a1b, arm_j2..j5, beak, reset_arm, "
+                  "set_home, reboot_arm, reboot_traction, joint_1a1b, joint_roll")
+
+    def _handle_monitor(self, args: list[str]) -> None:
+        filter_name = args[0].lower() if args else "all"
+        filter_set = NAMED_FILTERS.get(filter_name)
+
+        if filter_name not in NAMED_FILTERS:
+            print(f"Unknown filter: '{filter_name}'")
+            print(f"Available: {', '.join(NAMED_FILTERS.keys())}")
+            return
+
+        if self._monitor_thread and self._monitor_thread.is_alive():
+            self.monitor.stop()
+            self._monitor_thread.join(timeout=2.0)
+
+        print(f"Monitoring CAN bus (filter: {filter_name}). Press Ctrl+C to stop.")
+
+        try:
+            self.monitor.run(filter_types=filter_set)
+        except KeyboardInterrupt:
+            self.monitor.stop()
+            print("\nMonitor stopped.")
+
+    def _handle_test(self, args: list[str]) -> None:
+        if not args:
+            print(f"Available tests: {', '.join(TESTS.keys())}")
+            return
+
+        test_name = args[0].lower()
+        test_fn = TESTS.get(test_name)
+
+        if test_fn is None:
+            print(f"Unknown test: '{test_name}'")
+            print(f"Available: {', '.join(TESTS.keys())}")
+            return
+
+        if self._monitor_thread and self._monitor_thread.is_alive():
+            self.monitor.stop()
+            self._monitor_thread.join(timeout=2.0)
+
+        self._monitor_thread = threading.Thread(
+            target=self.monitor.run,
+            kwargs={"quiet": True},
+            daemon=True,
+        )
+        self._monitor_thread.start()
+        time.sleep(0.2)  # Let monitor start
+
+        if test_name == "full":
+            test_fn(self.sender, self.monitor)
+        elif test_name in ("traction", "traction_diff"):
+            test_fn(self.sender, self.target)
+        else:
+            test_fn(self.sender)
+
+        self.monitor.stop()
+        self._monitor_thread.join(timeout=2.0)
+
+    def _show_status(self) -> None:
+        stats = self.monitor.stats
+        if not stats:
+            print("No messages received yet. Run 'monitor' first.")
+            return
+
+        print("Message counts:")
+        for name, count in stats.items():
+            print(f"  {name}: {count}")
+
+        print("\nLast values:")
+        for name, values in self.monitor.last_values.items():
+            vals = {k: v for k, v in values.items() if not k.startswith("_")}
+            print(f"  {name}: {vals}")
+
+
+def main() -> None:
+    args = parse_args()
+
+    target_map = {
+        "MK2_MOD1": ModuleAddress.MK2_MOD1,
+        "MK2_MOD2": ModuleAddress.MK2_MOD2,
+        "MK2_MOD3": ModuleAddress.MK2_MOD3,
+    }
+    target = target_map[args.module]
+
+    print(f"Connecting to CAN bus: interface={args.interface}, "
+          f"channel={args.channel}, bitrate={args.bitrate}...")
+
+    try:
+        bus = can.Bus(
+            interface=args.interface,
+            channel=args.channel,
+            bitrate=args.bitrate,
+            data_bitrate=args.data_bitrate,
+            fd=True,
+        )
+    except Exception as e:
+        print(f"Failed to connect: {e}")
+        print("\nMake sure:")
+        print("  - USB2CAN adapter is connected")
+        print("  - On Linux: sudo ip link set can0 up type can bitrate 1000000 dbitrate 2000000 fd on")
+        print("  - On Windows: install gs_usb driver for Innomaker USB2CAN")
+        sys.exit(1)
+
+    print("Connected.\n")
+
+    try:
+        cli = CLI(bus, target)
+        cli.run()
+    finally:
+        bus.shutdown()
+        print("CAN bus closed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/can_tester/cli.py
+++ b/tools/can_tester/cli.py
@@ -19,6 +19,7 @@ Commands:
     send set_home [permanent]               Set current position as home (default: interim)
     send reboot_arm                         Reboot arm motors
     send reboot_traction                    Reboot traction motors
+    send torque <bitfield>                  Enable/disable per-motor torque (uint16 bitfield)
     stop                                    Emergency stop all motors
     monitor [filter]                        Start monitoring (filter: all|arm|traction|joint|feedback)
     test <name>                             Run test sequence (traction|arm_init|arm_joints|arm_beak|full)
@@ -198,6 +199,11 @@ class CLI:
             self.sender.reboot_traction(self.target)
             print("Rebooting traction motors...")
 
+        elif subcmd == "torque" and len(args) == 2:
+            bitfield = int(args[1], 0)  # Auto-detect hex (0x) or decimal
+            self.sender.torque_enable(bitfield, self.target)
+            print(f"Torque enable/disable: bitfield=0x{bitfield:04X}")
+
         elif subcmd == "joint_1a1b" and len(args) == 3:
             theta, phi = float(args[1]), float(args[2])
             self.sender.joint_pitch_1a1b(theta, phi, self.target)
@@ -211,7 +217,8 @@ class CLI:
         else:
             print(f"Unknown send command: '{subcmd}' with {len(args) - 1} args")
             print("Available: traction, arm_1a1b, arm_j2..j5, beak, reset_arm, "
-                  "set_home, reboot_arm, reboot_traction, joint_1a1b, joint_roll")
+                  "set_home, reboot_arm, reboot_traction, torque, "
+                  "joint_1a1b, joint_roll")
 
     def _handle_monitor(self, args: list[str]) -> None:
         filter_name = args[0].lower() if args else "all"

--- a/tools/can_tester/codec.py
+++ b/tools/can_tester/codec.py
@@ -10,16 +10,16 @@ from __future__ import annotations
 import struct
 from typing import Any
 
-from .protocol import (
-    MsgType,
-    PayloadFormat,
-    PAYLOAD_FORMATS,
-    encode_can_id,
-    decode_can_id,
-    DecodedID,
-    ModuleAddress,
-    MSG_NAMES,
-)
+try:
+    from .protocol import (
+        MsgType, PayloadFormat, PAYLOAD_FORMATS, encode_can_id,
+        decode_can_id, DecodedID, ModuleAddress, MSG_NAMES,
+    )
+except ImportError:
+    from protocol import (
+        MsgType, PayloadFormat, PAYLOAD_FORMATS, encode_can_id,
+        decode_can_id, DecodedID, ModuleAddress, MSG_NAMES,
+    )
 
 
 def encode_payload(msg_type: int, **kwargs: Any) -> bytes:

--- a/tools/can_tester/codec.py
+++ b/tools/can_tester/codec.py
@@ -1,0 +1,118 @@
+"""
+Encode and decode CAN message payloads for STM32LowLevel protocol.
+
+Provides high-level encode/decode functions that use the PayloadFormat
+descriptors from protocol.py.
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import Any
+
+from .protocol import (
+    MsgType,
+    PayloadFormat,
+    PAYLOAD_FORMATS,
+    encode_can_id,
+    decode_can_id,
+    DecodedID,
+    ModuleAddress,
+    MSG_NAMES,
+)
+
+
+def encode_payload(msg_type: int, **kwargs: Any) -> bytes:
+    """Encode keyword arguments into a CAN payload.
+
+    Args:
+        msg_type: MsgType value.
+        **kwargs: Field values matching the PayloadFormat field names.
+
+    Returns:
+        Packed bytes ready for CAN transmission.
+
+    Raises:
+        ValueError: If msg_type has no known format or fields are missing.
+
+    Example:
+        >>> encode_payload(MsgType.MOTOR_SETPOINT, right_rpm=10.0, left_rpm=10.0)
+        b'\\x00\\x00 A\\x00\\x00 A'
+    """
+    fmt = PAYLOAD_FORMATS.get(msg_type)
+    if fmt is None:
+        raise ValueError(f"No payload format for msg_type 0x{msg_type:02X}")
+
+    if not fmt.fmt:
+        return b""  # No-payload messages (RESET_ARM, REBOOT_ARM, etc.)
+
+    values = []
+    for field_name in fmt.fields:
+        if field_name not in kwargs:
+            raise ValueError(
+                f"Missing field '{field_name}' for {MSG_NAMES.get(msg_type, '?')}. "
+                f"Required: {fmt.fields}"
+            )
+        values.append(kwargs[field_name])
+
+    return struct.pack(fmt.fmt, *values)
+
+
+def decode_payload(msg_type: int, data: bytes) -> dict[str, Any]:
+    """Decode a CAN payload into a dict of named fields.
+
+    Args:
+        msg_type: MsgType value.
+        data: Raw CAN payload bytes.
+
+    Returns:
+        Dict mapping field names to decoded values.
+        Returns {"raw": data.hex()} for unknown message types.
+    """
+    fmt = PAYLOAD_FORMATS.get(msg_type)
+    if fmt is None:
+        return {"raw": data.hex()}
+
+    if not fmt.fmt:
+        return {}  # No-payload messages
+
+    try:
+        values = struct.unpack(fmt.fmt, data[: fmt.size])
+    except struct.error:
+        return {"raw": data.hex(), "error": "payload size mismatch"}
+
+    result = dict(zip(fmt.fields, values))
+    result["_unit"] = fmt.unit
+    return result
+
+
+def format_decoded(decoded_id: DecodedID, payload: dict[str, Any]) -> str:
+    """Format a decoded CAN message into a human-readable string.
+
+    Args:
+        decoded_id: Parsed CAN identifier.
+        payload: Decoded payload dict from decode_payload().
+
+    Returns:
+        Single-line formatted string.
+    """
+    parts = [
+        f"[{decoded_id.source_name} → {decoded_id.destination_name}]",
+        decoded_id.msg_name,
+    ]
+
+    unit = payload.pop("_unit", "")
+
+    for key, value in payload.items():
+        if key.startswith("_"):
+            continue
+        if isinstance(value, float):
+            parts.append(f"{key}={value:.4f}{' ' + unit if unit else ''}")
+        else:
+            parts.append(f"{key}={value}")
+
+    # Restore unit for potential re-use
+    if unit:
+        payload["_unit"] = unit
+
+    return "  ".join(parts)

--- a/tools/can_tester/header_parser.py
+++ b/tools/can_tester/header_parser.py
@@ -1,0 +1,280 @@
+"""
+Minimal C preprocessor for STM32LowLevel header files.
+
+Parses ``#define`` macros from communication.h and mod_config.h at runtime,
+correctly handling ``#if defined()``, ``#ifdef``, ``#ifndef``,
+``#if A == B``, ``#elif defined()``, ``#elif A == B``, ``#else``, and
+``#endif`` blocks so the Python CAN tester always reflects the firmware's
+actual definitions — no manual sync needed.
+
+Usage::
+
+    from header_parser import parse_communication_header, parse_mod_config
+
+    msg_defines = parse_communication_header()      # all CAN message IDs
+    mod_defines = parse_mod_config("MK2_MOD1")      # module-specific config
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Dict, Optional, Set
+
+# ─── paths ───────────────────────────────────────────────────────────────────
+
+_DEFAULT_INCLUDE_DIR = (
+    Path(__file__).resolve().parent.parent.parent
+    / "STM32LowLevel" / "Inc"
+)
+
+# ─── module address map (for parse_mod_config value injection) ────────────────
+
+_MODULE_ADDRESSES: dict[str, int] = {
+    "MK2_MOD1": 0x21,
+    "MK2_MOD2": 0x22,
+    "MK2_MOD3": 0x23,
+}
+
+# ─── regex ───────────────────────────────────────────────────────────────────
+
+# Matches:  #define NAME 0xFF  |  #define NAME 123
+_DEFINE_VALUE_RE = re.compile(
+    r"^\s*#define\s+(\w+)\s+(0[xX][0-9a-fA-F]+|\d+)"
+)
+# Matches:  #define NAME  (flag-style, no value)
+_DEFINE_FLAG_RE = re.compile(
+    r"^\s*#define\s+(\w+)\s*$"
+)
+# Matches:  #define NAME IDENTIFIER  (value is a non-numeric token)
+_DEFINE_IDENT_RE = re.compile(
+    r"^\s*#define\s+(\w+)\s+([a-zA-Z_]\w*)\s*(?:\/\/.*)?$"
+)
+# Matches:  #if defined(NAME)  |  #ifdef NAME
+_IF_DEFINED_RE = re.compile(
+    r"^\s*#if\s+defined\s*\(\s*(\w+)\s*\)|^\s*#ifdef\s+(\w+)"
+)
+# Matches:  #elif defined(NAME)
+_ELIF_DEFINED_RE = re.compile(
+    r"^\s*#elif\s+defined\s*\(\s*(\w+)\s*\)"
+)
+# Matches:  #ifndef NAME
+_IFNDEF_RE = re.compile(
+    r"^\s*#ifndef\s+(\w+)"
+)
+# Matches:  #if A == B  (where A/B are hex literals, decimal, or identifiers)
+_IF_EQ_RE = re.compile(
+    r"^\s*#if\s+(\w+)\s*==\s*(0[xX][0-9a-fA-F]+|\d+|\w+)"
+)
+# Matches:  #elif A == B
+_ELIF_EQ_RE = re.compile(
+    r"^\s*#elif\s+(\w+)\s*==\s*(0[xX][0-9a-fA-F]+|\d+|\w+)"
+)
+
+
+# ─── preprocessor engine ────────────────────────────────────────────────────
+
+def preprocess_header(
+    path: Path,
+    predefined: Optional[Set[str]] = None,
+    predefined_values: Optional[Dict[str, int]] = None,
+) -> Dict[str, int]:
+    """Parse a C header file through a minimal preprocessor.
+
+    Handles ``#define``, ``#if defined()``, ``#ifdef``, ``#ifndef``,
+    ``#if A == B``, ``#elif defined()``, ``#elif A == B``, ``#else``,
+    and ``#endif``.
+
+    Args:
+        path: Path to the ``.h`` file.
+        predefined: Set of macro names to treat as already defined
+                    (flag-style, e.g. ``{"MK2_MOD1"}``).
+        predefined_values: Dict of macro name → integer value for value-style
+                    predefined macros (e.g. ``{"MODULE_DEFINE": 0x21}``).
+
+    Returns:
+        ``{MACRO_NAME: int_value}`` for every ``#define NAME <number>``
+        that is active given the conditionals.
+    """
+    predefined = predefined or set()
+    predefined_values = predefined_values or {}
+    known_flags: Set[str] = set(predefined)  # tracks flag defines
+    defines: Dict[str, int] = {}
+
+    # Stack of (this_branch_active, any_branch_taken) per nesting level.
+    cond_stack: list[tuple[bool, bool]] = []
+
+    def _active() -> bool:
+        return all(active for active, _ in cond_stack)
+
+    def _resolve(token: str) -> Optional[int]:
+        """Resolve a token to an integer: literal, define, or predefined_value."""
+        try:
+            return int(token, 0)
+        except ValueError:
+            pass
+        if token in defines:
+            return defines[token]
+        if token in predefined_values:
+            return predefined_values[token]
+        return None
+
+    with open(path, "r") as fh:
+        for raw_line in fh:
+            line = raw_line.strip()
+
+            # ── #ifndef ─────────────────────────────────────────────
+            m = _IFNDEF_RE.match(line)
+            if m:
+                name = m.group(1)
+                active = name not in known_flags
+                cond_stack.append((active, active))
+                continue
+
+            # ── #if defined(NAME) / #ifdef NAME ─────────────────────
+            m = _IF_DEFINED_RE.match(line)
+            if m:
+                name = m.group(1) or m.group(2)
+                active = name in known_flags
+                cond_stack.append((active, active))
+                continue
+
+            # ── #if A == B ──────────────────────────────────────────
+            m = _IF_EQ_RE.match(line)
+            if m:
+                lhs = _resolve(m.group(1))
+                rhs = _resolve(m.group(2))
+                active = (lhs is not None and rhs is not None and lhs == rhs)
+                cond_stack.append((active, active))
+                continue
+
+            # ── #elif defined(NAME) ─────────────────────────────────
+            m = _ELIF_DEFINED_RE.match(line)
+            if m and cond_stack:
+                name = m.group(1)
+                _, any_taken = cond_stack[-1]
+                if any_taken:
+                    cond_stack[-1] = (False, True)
+                else:
+                    active = name in known_flags
+                    cond_stack[-1] = (active, active)
+                continue
+
+            # ── #elif A == B ────────────────────────────────────────
+            m = _ELIF_EQ_RE.match(line)
+            if m and cond_stack:
+                _, any_taken = cond_stack[-1]
+                if any_taken:
+                    cond_stack[-1] = (False, True)
+                else:
+                    lhs = _resolve(m.group(1))
+                    rhs = _resolve(m.group(2))
+                    active = (lhs is not None and rhs is not None and lhs == rhs)
+                    cond_stack[-1] = (active, active)
+                continue
+
+            # ── #else ───────────────────────────────────────────────
+            if line.startswith("#else") and cond_stack:
+                _, any_taken = cond_stack[-1]
+                cond_stack[-1] = (not any_taken, True)
+                continue
+
+            # ── #endif ──────────────────────────────────────────────
+            if line.startswith("#endif") and cond_stack:
+                cond_stack.pop()
+                continue
+
+            # Only process defines when all enclosing conditionals active
+            if not _active():
+                continue
+
+            # ── #define NAME VALUE (numeric) ────────────────────────
+            m = _DEFINE_VALUE_RE.match(raw_line)
+            if m:
+                name, val = m.group(1), m.group(2)
+                defines[name] = int(val, 0)
+                known_flags.add(name)
+                continue
+
+            # ── #define NAME IDENTIFIER (resolve via defines) ────────
+            m = _DEFINE_IDENT_RE.match(raw_line)
+            if m:
+                name, ident = m.group(1), m.group(2)
+                val = _resolve(ident)
+                if val is not None:
+                    defines[name] = val
+                known_flags.add(name)
+                continue
+
+            # ── #define NAME (flag) ─────────────────────────────────
+            m = _DEFINE_FLAG_RE.match(raw_line)
+            if m:
+                known_flags.add(m.group(1))
+
+    return defines
+
+
+# ─── convenience wrappers ────────────────────────────────────────────────────
+
+def parse_communication_header(
+    include_dir: Optional[Path] = None,
+) -> Dict[str, int]:
+    """Parse ``communication.h`` and return all CAN message-type defines.
+
+    Returns:
+        ``{MACRO_NAME: int_value}`` — every ``#define`` with a numeric value,
+        excluding include guards.
+
+    Raises:
+        FileNotFoundError: if communication.h is not at the expected path.
+    """
+    include_dir = include_dir or _DEFAULT_INCLUDE_DIR
+    path = include_dir / "communication.h"
+
+    if not path.exists():
+        raise FileNotFoundError(
+            f"communication.h not found at {path}. "
+            f"Ensure you're running from within the STM32LowLevel repo."
+        )
+
+    return preprocess_header(path)
+
+
+def parse_mod_config(
+    module_variant: str = "MK2_MOD1",
+    include_dir: Optional[Path] = None,
+) -> Dict[str, int]:
+    """Parse ``mod_config.h`` with a specific module variant active.
+
+    STM32LowLevel's mod_config.h uses ``#if MODULE_DEFINE == MK2_MOD1``
+    value-comparison guards. The module variant address is injected as
+    ``MODULE_DEFINE`` so those conditionals resolve correctly.
+
+    Args:
+        module_variant: One of MK2_MOD1, MK2_MOD2, MK2_MOD3.
+        include_dir: Override for the include directory path.
+
+    Returns:
+        ``{MACRO_NAME: int_value}`` for numeric defines active under the
+        chosen variant.
+
+    Raises:
+        FileNotFoundError: if mod_config.h is not at the expected path.
+        ValueError: if module_variant is not a known MK2 variant.
+    """
+    if module_variant not in _MODULE_ADDRESSES:
+        raise ValueError(
+            f"Unknown module variant '{module_variant}'. "
+            f"Valid values: {list(_MODULE_ADDRESSES.keys())}"
+        )
+
+    include_dir = include_dir or _DEFAULT_INCLUDE_DIR
+    path = include_dir / "mod_config.h"
+
+    if not path.exists():
+        raise FileNotFoundError(f"mod_config.h not found at {path}")
+
+    return preprocess_header(
+        path,
+        predefined_values={"MODULE_DEFINE": _MODULE_ADDRESSES[module_variant]},
+    )

--- a/tools/can_tester/monitor.py
+++ b/tools/can_tester/monitor.py
@@ -1,0 +1,161 @@
+"""
+Real-time CAN bus monitor with protocol-aware decoding.
+
+Listens for CAN messages and prints decoded output to the terminal.
+"""
+
+from __future__ import annotations
+
+import can
+import time
+import sys
+from typing import Optional, Callable
+
+from .protocol import decode_can_id, MsgType, MSG_NAMES
+from .codec import decode_payload, format_decoded
+
+
+class CanMonitor:
+    """Monitor CAN bus traffic with protocol-aware decoding."""
+
+    def __init__(self, bus: can.BusABC):
+        self.bus = bus
+        self._running = False
+        self._msg_counts: dict[int, int] = {}
+        self._last_values: dict[int, dict] = {}
+        self._callbacks: list[Callable] = []
+
+    def add_callback(self, callback: Callable) -> None:
+        """Register a callback for each received message.
+
+        Callback signature: callback(decoded_id, payload, raw_msg)
+        """
+        self._callbacks.append(callback)
+
+    def run(
+        self,
+        filter_types: Optional[set[int]] = None,
+        duration: Optional[float] = None,
+        quiet: bool = False,
+    ) -> None:
+        """Start monitoring CAN bus traffic.
+
+        Args:
+            filter_types: If set, only show these MsgType values.
+            duration: Run for this many seconds, then stop. None = forever.
+            quiet: If True, suppress terminal output (callbacks still fire).
+        """
+        self._running = True
+        start = time.time()
+
+        try:
+            while self._running:
+                if duration and (time.time() - start) >= duration:
+                    break
+
+                msg = self.bus.recv(timeout=0.1)
+                if msg is None:
+                    continue
+
+                decoded_id = decode_can_id(msg.arbitration_id)
+
+                if filter_types and decoded_id.msg_type not in filter_types:
+                    continue
+
+                payload = decode_payload(decoded_id.msg_type, bytes(msg.data))
+
+                # Track statistics
+                self._msg_counts[decoded_id.msg_type] = (
+                    self._msg_counts.get(decoded_id.msg_type, 0) + 1
+                )
+                self._last_values[decoded_id.msg_type] = payload
+
+                # Fire callbacks
+                for cb in self._callbacks:
+                    cb(decoded_id, payload, msg)
+
+                if not quiet:
+                    ts = f"{msg.timestamp:.3f}" if msg.timestamp else f"{time.time():.3f}"
+                    line = format_decoded(decoded_id, payload)
+                    print(f"[{ts}] {line}")
+
+        except KeyboardInterrupt:
+            pass
+        finally:
+            self._running = False
+
+    def stop(self) -> None:
+        """Stop the monitor loop."""
+        self._running = False
+
+    @property
+    def stats(self) -> dict[str, int]:
+        """Return message count statistics."""
+        return {
+            MSG_NAMES.get(k, f"0x{k:02X}"): v
+            for k, v in sorted(self._msg_counts.items())
+        }
+
+    @property
+    def last_values(self) -> dict[str, dict]:
+        """Return last decoded values for each message type."""
+        return {
+            MSG_NAMES.get(k, f"0x{k:02X}"): v
+            for k, v in self._last_values.items()
+        }
+
+
+# ─── Predefined filters ─────────────────────────────────────────────────────
+
+FILTER_ARM = {
+    MsgType.ARM_PITCH_1a1b_SETPOINT, MsgType.ARM_PITCH_1a1b_FEEDBACK,
+    MsgType.ARM_PITCH_2_SETPOINT, MsgType.ARM_PITCH_2_FEEDBACK,
+    MsgType.ARM_ROLL_3_SETPOINT, MsgType.ARM_ROLL_3_FEEDBACK,
+    MsgType.ARM_PITCH_4_SETPOINT, MsgType.ARM_PITCH_4_FEEDBACK,
+    MsgType.ARM_ROLL_5_SETPOINT, MsgType.ARM_ROLL_5_FEEDBACK,
+    MsgType.ARM_ROLL_6_SETPOINT, MsgType.ARM_ROLL_6_FEEDBACK,
+    MsgType.RESET_ARM, MsgType.REBOOT_ARM,
+    MsgType.ARM_PITCH_1a1b_FEEDBACK_VEL, MsgType.ARM_PITCH_2_FEEDBACK_VEL,
+    MsgType.ARM_ROLL_3_FEEDBACK_VEL, MsgType.ARM_PITCH_4_FEEDBACK_VEL,
+    MsgType.ARM_ROLL_5_FEEDBACK_VEL, MsgType.ARM_ROLL_6_FEEDBACK_VEL,
+    MsgType.MOTOR_ARM_ERROR_STATUS,
+}
+
+FILTER_TRACTION = {
+    MsgType.MOTOR_SETPOINT, MsgType.MOTOR_FEEDBACK,
+    MsgType.MOTOR_TRACTION_REBOOT, MsgType.MOTOR_TRACTION_ERROR_STATUS,
+}
+
+FILTER_JOINT = {
+    MsgType.JOINT_PITCH_1a1b_SETPOINT, MsgType.JOINT_PITCH_1a1b_FEEDBACK,
+    MsgType.JOINT_ROLL_2_SETPOINT, MsgType.JOINT_ROLL_2_FEEDBACK,
+    MsgType.JOINT_YAW_FEEDBACK,
+    MsgType.JOINT_PITCH_FEEDBACK, MsgType.JOINT_ROLL_FEEDBACK,
+}
+
+FILTER_IMU = {
+    MsgType.JOINT_PITCH_FEEDBACK, MsgType.JOINT_ROLL_FEEDBACK,
+    MsgType.IMU_RAW_ACCEL, MsgType.IMU_RAW_GYRO,
+}
+
+FILTER_FEEDBACK = {
+    MsgType.MOTOR_FEEDBACK, MsgType.JOINT_YAW_FEEDBACK,
+    MsgType.JOINT_PITCH_FEEDBACK, MsgType.JOINT_ROLL_FEEDBACK,
+    MsgType.ARM_PITCH_1a1b_FEEDBACK, MsgType.ARM_PITCH_2_FEEDBACK,
+    MsgType.ARM_ROLL_3_FEEDBACK, MsgType.ARM_PITCH_4_FEEDBACK,
+    MsgType.ARM_ROLL_5_FEEDBACK, MsgType.ARM_ROLL_6_FEEDBACK,
+    MsgType.ARM_PITCH_1a1b_FEEDBACK_VEL, MsgType.ARM_PITCH_2_FEEDBACK_VEL,
+    MsgType.ARM_ROLL_3_FEEDBACK_VEL, MsgType.ARM_PITCH_4_FEEDBACK_VEL,
+    MsgType.ARM_ROLL_5_FEEDBACK_VEL, MsgType.ARM_ROLL_6_FEEDBACK_VEL,
+    MsgType.JOINT_PITCH_1a1b_FEEDBACK, MsgType.JOINT_ROLL_2_FEEDBACK,
+    MsgType.MOTOR_TRACTION_ERROR_STATUS, MsgType.MOTOR_ARM_ERROR_STATUS,
+}
+
+NAMED_FILTERS = {
+    "arm": FILTER_ARM,
+    "traction": FILTER_TRACTION,
+    "joint": FILTER_JOINT,
+    "imu": FILTER_IMU,
+    "feedback": FILTER_FEEDBACK,
+    "all": None,
+}

--- a/tools/can_tester/monitor.py
+++ b/tools/can_tester/monitor.py
@@ -51,6 +51,8 @@ class CanMonitor:
         """
         self._running = True
         start = time.time()
+        recv_count = 0
+        none_count = 0
 
         try:
             while self._running:
@@ -59,7 +61,12 @@ class CanMonitor:
 
                 msg = self.bus.recv(timeout=0.1)
                 if msg is None:
+                    none_count += 1
+                    if none_count % 50 == 0:
+                        print(f"[monitor] {none_count} timeouts, {recv_count} received so far", flush=True)
                     continue
+
+                recv_count += 1
 
                 decoded_id = decode_can_id(msg.arbitration_id)
 
@@ -81,7 +88,9 @@ class CanMonitor:
                 if not quiet:
                     ts = f"{msg.timestamp:.3f}" if msg.timestamp else f"{time.time():.3f}"
                     line = format_decoded(decoded_id, payload)
-                    print(f"[{ts}] {line}")
+                    print(f"[{ts}] {line}", flush=True)
+                    if not msg.is_fd:
+                        print(f"  RAW id=0x{msg.arbitration_id:08X} data={msg.data.hex()}", flush=True)
 
         except KeyboardInterrupt:
             pass

--- a/tools/can_tester/monitor.py
+++ b/tools/can_tester/monitor.py
@@ -11,8 +11,12 @@ import time
 import sys
 from typing import Optional, Callable
 
-from .protocol import decode_can_id, MsgType, MSG_NAMES
-from .codec import decode_payload, format_decoded
+try:
+    from .protocol import decode_can_id, MsgType, MSG_NAMES
+    from .codec import decode_payload, format_decoded
+except ImportError:
+    from protocol import decode_can_id, MsgType, MSG_NAMES
+    from codec import decode_payload, format_decoded
 
 
 class CanMonitor:
@@ -151,11 +155,16 @@ FILTER_FEEDBACK = {
     MsgType.MOTOR_TRACTION_ERROR_STATUS, MsgType.MOTOR_ARM_ERROR_STATUS,
 }
 
+FILTER_BATTERY = {
+    MsgType.BATTERY_VOLTAGE, MsgType.BATTERY_PERCENT, MsgType.BATTERY_TEMPERATURE,
+}
+
 NAMED_FILTERS = {
     "arm": FILTER_ARM,
     "traction": FILTER_TRACTION,
     "joint": FILTER_JOINT,
     "imu": FILTER_IMU,
     "feedback": FILTER_FEEDBACK,
+    "battery": FILTER_BATTERY,
     "all": None,
 }

--- a/tools/can_tester/procedure.md
+++ b/tools/can_tester/procedure.md
@@ -1,0 +1,159 @@
+# CAN Tester — Testing Procedures
+
+This document describes when and how to use the CAN testing tool during
+development, integration, and maintenance of the STM32LowLevel firmware.
+
+---
+
+## When to Test
+
+| Scenario | What to test | Tool |
+|----------|-------------|------|
+| **New firmware upload** | All motors respond, feedback messages arrive | Web dashboard — full diagnostic |
+| **Mechanical change** (shaft/arm repositioned) | Arm home position is safe, no collisions | Dashboard — `reset_arm`, monitor feedback |
+| **After fixing a bug** | Specific subsystem affected by the fix | Dashboard or CLI — targeted commands |
+| **CAN wiring change** | All modules reachable, no bus errors | Dashboard — listen to all three modules |
+| **New motor / Dynamixel replaced** | Motor responds to setpoints, error status clear | Dashboard — individual joint commands |
+| **Pre-competition check** | End-to-end system health | CLI — `test full` sequence |
+| **Debugging intermittent issues** | Monitor traffic patterns over time | Dashboard — leave running with filters |
+
+---
+
+## Procedure 1: Verify Traction Motors
+
+**Purpose**: Confirm both traction motors on a module respond correctly.
+
+1. Power on the module. Connect USB2CAN to the CAN bus.
+2. Start dashboard: `python -m tools.can_tester.web_dashboard -i gs_usb -c 0 --port 8080`
+3. Select the target module (e.g. MK2_MOD1).
+4. Select **Traction Motors** command.
+5. Enter small values first: Right RPM = `5`, Left RPM = `5`. Click **Send**.
+6. Observe:
+   - Motors should spin forward at low speed.
+   - `MOTOR_FEEDBACK` messages should appear in the live feed showing actual RPM.
+7. Try differential: Right = `20`, Left = `-20` (spin in place).
+8. Click **STOP ALL** to halt.
+9. Check for `MOTOR_TRACTION_ERROR_STATUS` messages — both bytes should be `0`.
+
+**Expected**: Motors respond within ~100 ms, feedback RPM matches setpoint
+within ±10%.
+
+---
+
+## Procedure 2: Verify Robotic Arm (MOD1 Only)
+
+**Purpose**: Confirm all 6 arm joints + beak respond correctly.
+
+> **Safety**: Ensure the arm is free to move. Keep hands clear. Start with
+> small angles.
+
+1. Start dashboard, select **MK2_MOD1**.
+2. Send **Reset Arm** — arm should move to home position.
+3. Monitor `ARM_*_FEEDBACK` messages to confirm positions near zero.
+4. Test each joint individually:
+   - **Arm J1 (1a1b)**: Theta = `0.1`, Phi = `0.0` → shoulder should yaw slightly.
+   - **Arm J2**: Angle = `0.2` → elbow should bend slightly.
+   - **Arm J3**: Angle = `0.1` → forearm should rotate slightly.
+   - **Arm J4**: Angle = `0.1` → wrist should pitch slightly.
+   - **Arm J5**: Angle = `0.1` → wrist should rotate slightly.
+5. Send **Beak Close**, then **Beak Open** — gripper should actuate.
+6. Send **Reset Arm** to return to home.
+7. Check `MOTOR_ARM_ERROR_STATUS` — all 7 bytes should be `0`.
+
+**Expected**: Each joint moves smoothly, feedback matches setpoint within
+~0.05 rad. No error flags.
+
+---
+
+## Procedure 3: Verify Inter-Module Joints (MOD2/MOD3)
+
+**Purpose**: Confirm the inter-module joint motors on middle/tail modules work.
+
+1. Start dashboard, select **MK2_MOD2** (or MOD3).
+2. Select **Joint Pitch (1a1b)**: Theta = `0.1`, Phi = `0.0`. Send.
+3. Observe `JOINT_PITCH_1a1b_FEEDBACK` — should reflect the setpoint.
+4. Select **Joint Roll**: Angle = `0.1`. Send.
+5. Observe `JOINT_ROLL_2_FEEDBACK`.
+6. Return to zero: send both with `0.0`.
+
+**Expected**: Joint responds, feedback matches within ~0.05 rad.
+
+---
+
+## Procedure 4: CAN Bus Health Check
+
+**Purpose**: Verify all modules are alive and communicating.
+
+1. Start dashboard in monitoring mode (no commands needed).
+2. Filter: **All**. Watch for periodic messages from each module:
+   - `BATTERY_VOLTAGE`, `BATTERY_PERCENT` from each module.
+   - `MOTOR_FEEDBACK` if traction is active.
+3. Check the **Statistics** panel — each expected message type should
+   have a nonzero count.
+4. If a module is missing: check CAN wiring, termination resistor (120 Ω),
+   and power supply.
+
+---
+
+## Procedure 5: Error Recovery
+
+**Purpose**: Clear motor error states and verify recovery.
+
+1. If `MOTOR_TRACTION_ERROR_STATUS` or `MOTOR_ARM_ERROR_STATUS` shows
+   nonzero values:
+2. Send **Reboot Traction** (for traction errors) or **Reboot Arm**
+   (for arm errors).
+3. Wait 2–3 seconds for motors to re-initialize.
+4. Send a small setpoint to verify the motor responds.
+5. Monitor error status — should return to all zeros.
+
+---
+
+## Procedure 6: Full Diagnostic (CLI)
+
+**Purpose**: Automated end-to-end test of all subsystems.
+
+```bash
+python -m tools.can_tester -i gs_usb -c 0
+> test full
+```
+
+This runs all test sequences in order:
+1. Traction forward/stop/reverse
+2. Differential turning
+3. Arm reset + individual joint sweep
+4. Beak open/close
+5. Arm motor reboot
+
+Monitor the output for any failures or timeouts.
+
+---
+
+## Procedure 7: Offline Validation
+
+**Purpose**: Verify the tool's protocol layer without hardware.
+
+```bash
+cd STM32LowLevel
+python -m tools.can_tester.test_dry
+```
+
+This validates:
+- CAN ID encoding/decoding round-trip
+- Payload codec for all message types
+- Header parser output matches protocol definitions
+- MsgType enum completeness (all 44 message types)
+
+Run this after any change to `protocol.py`, `codec.py`, or `communication.h`.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| "No gs_usb device found" | WinUSB driver not installed | See README.md — Windows setup |
+| Dashboard shows no messages | CAN wiring disconnected or wrong bitrate | Check wiring; must be 125 kbps |
+| Motors don't respond to setpoints | Module not powered or CAN ID mismatch | Verify module address in module selector |
+| `MOTOR_*_ERROR_STATUS` nonzero | Motor in error state (overload, overtemp) | Send reboot command, check mechanical load |
+| Messages from unknown address | MK1 module or misconfigured firmware | Check `mod_config.h` build defines |

--- a/tools/can_tester/protocol.py
+++ b/tools/can_tester/protocol.py
@@ -92,6 +92,7 @@ class MsgType(IntEnum):
     MOTOR_TRACTION_REBOOT = 0x71
     MOTOR_TRACTION_ERROR_STATUS = 0x72
     MOTOR_ARM_ERROR_STATUS = 0x73
+    TORQUE_ENABLE_DISABLE = 0x74
 
     # Arm velocity feedback
     ARM_PITCH_1a1b_FEEDBACK_VEL = 0x80
@@ -215,6 +216,9 @@ PAYLOAD_FORMATS: dict[int, PayloadFormat] = {
 
     # Traction control (no payload)
     MsgType.MOTOR_TRACTION_REBOOT: PayloadFormat("", [], ""),
+
+    # Torque enable/disable — uint16 bitfield
+    MsgType.TORQUE_ENABLE_DISABLE: PayloadFormat("<H", ["torque_bitfield"], "bits"),
 
     # IMU raw data (debug)
     MsgType.IMU_RAW_ACCEL: PayloadFormat("<fff", ["ax", "ay", "az"], "g"),

--- a/tools/can_tester/protocol.py
+++ b/tools/can_tester/protocol.py
@@ -1,0 +1,277 @@
+"""
+CAN bus protocol definitions for STM32LowLevel firmware.
+
+Defines the authoritative MsgType enum and CAN ID encoding/decoding.
+At import time, optionally validates against communication.h via
+header_parser — if the header has new or changed defines, a warning
+is printed so the developer can update this file.
+
+Extended CAN (29-bit) identifiers based on J1939:
+    - SA  [0:7]   Source Address (module ID)
+    - PS  [8:15]  Destination Address
+    - PF  [16:23] PDU Format (message type)
+    - EFF bit[31]  Extended Frame Flag (set by CAN driver)
+
+Identifier encoding (little-endian bytes):
+    byte0 = source_address
+    byte1 = destination_address
+    byte2 = message_type (PDU Format)
+    byte3 = 0x00 (set by CAN driver for EFF)
+"""
+
+from __future__ import annotations
+
+import struct
+import warnings
+from enum import IntEnum
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+# ─── Module addresses ────────────────────────────────────────────────────────
+
+class ModuleAddress(IntEnum):
+    """Module CAN addresses. Format: 0xYX where Y=version, X=ordinal."""
+    CENTRAL = 0x00   # Jetson / PC
+    MK2_MOD1 = 0x21  # Head module (arm)
+    MK2_MOD2 = 0x22  # Middle module (joint)
+    MK2_MOD3 = 0x23  # Tail module (joint)
+
+
+# ─── Message types (authoritative — manually synced with communication.h) ───
+
+class MsgType(IntEnum):
+    """CAN message types. Keep in sync with STM32LowLevel/Inc/communication.h."""
+
+    # Battery
+    BATTERY_VOLTAGE = 0x11
+    BATTERY_PERCENT = 0x12
+    BATTERY_TEMPERATURE = 0x13
+
+    # Traction
+    MOTOR_SETPOINT = 0x21
+    MOTOR_FEEDBACK = 0x22
+
+    # Joint / IMU orientation feedback
+    JOINT_YAW_FEEDBACK = 0x32
+    JOINT_PITCH_FEEDBACK = 0x34
+    JOINT_ROLL_FEEDBACK = 0x36
+
+    # End Effector (MK1 legacy)
+    DATA_EE_PITCH_SETPOINT = 0x41
+    DATA_EE_PITCH_FEEDBACK = 0x42
+    DATA_EE_HEAD_PITCH_SETPOINT = 0x43
+    DATA_EE_HEAD_PITCH_FEEDBACK = 0x44
+    DATA_EE_HEAD_ROLL_SETPOINT = 0x45
+    DATA_EE_HEAD_ROLL_FEEDBACK = 0x46
+
+    # Robotic arm (MOD1 only)
+    ARM_PITCH_1a1b_SETPOINT = 0x51
+    ARM_PITCH_1a1b_FEEDBACK = 0x52
+    ARM_PITCH_2_SETPOINT = 0x53
+    ARM_PITCH_2_FEEDBACK = 0x54
+    ARM_ROLL_3_SETPOINT = 0x55
+    ARM_ROLL_3_FEEDBACK = 0x56
+    ARM_PITCH_4_SETPOINT = 0x57
+    ARM_PITCH_4_FEEDBACK = 0x58
+    ARM_ROLL_5_SETPOINT = 0x59
+    ARM_ROLL_5_FEEDBACK = 0x5A
+    ARM_ROLL_6_SETPOINT = 0x5B
+    ARM_ROLL_6_FEEDBACK = 0x5C
+    RESET_ARM = 0x5D
+    REBOOT_ARM = 0x5E
+    SET_HOME = 0x5F
+
+    # Inter-module joints (MOD2/MOD3)
+    JOINT_PITCH_1a1b_SETPOINT = 0x61
+    JOINT_PITCH_1a1b_FEEDBACK = 0x62
+    JOINT_ROLL_2_SETPOINT = 0x63
+    JOINT_ROLL_2_FEEDBACK = 0x64
+
+    # Motor control / status
+    MOTOR_TRACTION_REBOOT = 0x71
+    MOTOR_TRACTION_ERROR_STATUS = 0x72
+    MOTOR_ARM_ERROR_STATUS = 0x73
+
+    # Arm velocity feedback
+    ARM_PITCH_1a1b_FEEDBACK_VEL = 0x80
+    ARM_PITCH_2_FEEDBACK_VEL = 0x81
+    ARM_ROLL_3_FEEDBACK_VEL = 0x82
+    ARM_PITCH_4_FEEDBACK_VEL = 0x83
+    ARM_ROLL_5_FEEDBACK_VEL = 0x84
+    ARM_ROLL_6_FEEDBACK_VEL = 0x85
+
+    # IMU raw data (debug)
+    IMU_RAW_ACCEL = 0x92
+    IMU_RAW_GYRO = 0x93
+
+
+# ─── Validate against communication.h (optional) ────────────────────────────
+
+try:
+    from .header_parser import parse_communication_header
+    _header_defines = parse_communication_header()
+
+    # Check for defines in the header that are missing or different here
+    _py_defines = {m.name: m.value for m in MsgType}
+    _missing = {k: v for k, v in _header_defines.items() if k not in _py_defines}
+    _changed = {
+        k: (v, _py_defines[k])
+        for k, v in _header_defines.items()
+        if k in _py_defines and v != _py_defines[k]
+    }
+    _extra = {k: v for k, v in _py_defines.items() if k not in _header_defines}
+    if _missing or _changed or _extra:
+        parts = []
+        if _missing:
+            parts.append(f"New defines in communication.h not in protocol.py: {_missing}")
+        if _changed:
+            parts.append(f"Changed values: {_changed}")
+        if _extra:
+            parts.append(f"Python-only entries not in communication.h: {_extra}")
+        warnings.warn(
+            "protocol.py is out of sync with communication.h — "
+            + "; ".join(parts),
+            stacklevel=2,
+        )
+except (FileNotFoundError, ImportError):
+    pass  # Running outside the repo — skip validation
+
+
+# ─── Human-readable names ───────────────────────────────────────────────────
+
+MSG_NAMES: dict[int, str] = {m.value: m.name for m in MsgType}
+MODULE_NAMES: dict[int, str] = {m.value: m.name for m in ModuleAddress}
+
+
+# ─── Payload format descriptors ─────────────────────────────────────────────
+
+@dataclass
+class PayloadFormat:
+    """Describes the encoding of a CAN message payload."""
+    fmt: str            # struct format string (little-endian)
+    fields: list[str]   # field names
+    unit: str = ""      # unit label
+    size: int = field(init=False)
+
+    def __post_init__(self):
+        self.size = struct.calcsize(self.fmt)
+
+
+# Maps MsgType → PayloadFormat
+PAYLOAD_FORMATS: dict[int, PayloadFormat] = {
+    # Traction
+    MsgType.MOTOR_SETPOINT: PayloadFormat("<ff", ["right_rpm", "left_rpm"], "RPM"),
+    MsgType.MOTOR_FEEDBACK: PayloadFormat("<ff", ["left_rpm", "right_rpm"], "RPM"),
+
+    # Battery
+    MsgType.BATTERY_VOLTAGE: PayloadFormat("<f", ["voltage"], "V"),
+    MsgType.BATTERY_PERCENT: PayloadFormat("<f", ["percent"], "%"),
+    MsgType.BATTERY_TEMPERATURE: PayloadFormat("<f", ["temperature"], "°C"),
+
+    # Joint / IMU orientation feedback
+    MsgType.JOINT_YAW_FEEDBACK: PayloadFormat("<f", ["angle"], "deg"),
+    MsgType.JOINT_PITCH_FEEDBACK: PayloadFormat("<f", ["pitch"], "rad"),
+    MsgType.JOINT_ROLL_FEEDBACK: PayloadFormat("<f", ["roll"], "rad"),
+
+    # Arm position setpoints / feedback
+    MsgType.ARM_PITCH_1a1b_SETPOINT: PayloadFormat("<ff", ["theta", "phi"], "rad"),
+    MsgType.ARM_PITCH_1a1b_FEEDBACK: PayloadFormat("<ff", ["theta", "phi"], "rad"),
+    MsgType.ARM_PITCH_2_SETPOINT: PayloadFormat("<f", ["angle"], "rad"),
+    MsgType.ARM_PITCH_2_FEEDBACK: PayloadFormat("<f", ["angle"], "rad"),
+    MsgType.ARM_ROLL_3_SETPOINT: PayloadFormat("<f", ["angle"], "rad"),
+    MsgType.ARM_ROLL_3_FEEDBACK: PayloadFormat("<f", ["angle"], "rad"),
+    MsgType.ARM_PITCH_4_SETPOINT: PayloadFormat("<f", ["angle"], "rad"),
+    MsgType.ARM_PITCH_4_FEEDBACK: PayloadFormat("<f", ["angle"], "rad"),
+    MsgType.ARM_ROLL_5_SETPOINT: PayloadFormat("<f", ["angle"], "rad"),
+    MsgType.ARM_ROLL_5_FEEDBACK: PayloadFormat("<f", ["angle"], "rad"),
+    MsgType.ARM_ROLL_6_SETPOINT: PayloadFormat("<i", ["command"], "0=close(PWM-limited hold),1=open"),
+    MsgType.ARM_ROLL_6_FEEDBACK: PayloadFormat("<f", ["angle"], "rad"),
+
+    # Arm commands (no payload)
+    MsgType.RESET_ARM: PayloadFormat("", [], ""),
+    MsgType.REBOOT_ARM: PayloadFormat("", [], ""),
+    MsgType.SET_HOME: PayloadFormat("<i", ["persist"], "0=interim,1=permanent"),
+
+    # Arm velocity feedback
+    MsgType.ARM_PITCH_1a1b_FEEDBACK_VEL: PayloadFormat("<ff", ["theta_vel", "phi_vel"], "rad/s"),
+    MsgType.ARM_PITCH_2_FEEDBACK_VEL: PayloadFormat("<f", ["velocity"], "rad/s"),
+    MsgType.ARM_ROLL_3_FEEDBACK_VEL: PayloadFormat("<f", ["velocity"], "rad/s"),
+    MsgType.ARM_PITCH_4_FEEDBACK_VEL: PayloadFormat("<f", ["velocity"], "rad/s"),
+    MsgType.ARM_ROLL_5_FEEDBACK_VEL: PayloadFormat("<f", ["velocity"], "rad/s"),
+    MsgType.ARM_ROLL_6_FEEDBACK_VEL: PayloadFormat("<f", ["velocity"], "rad/s"),
+
+    # Inter-module joints
+    MsgType.JOINT_PITCH_1a1b_SETPOINT: PayloadFormat("<ff", ["theta", "phi"], "rad"),
+    MsgType.JOINT_PITCH_1a1b_FEEDBACK: PayloadFormat("<ff", ["theta", "phi"], "rad"),
+    MsgType.JOINT_ROLL_2_SETPOINT: PayloadFormat("<f", ["angle"], "rad"),
+    MsgType.JOINT_ROLL_2_FEEDBACK: PayloadFormat("<f", ["angle"], "rad"),
+
+    # Status
+    MsgType.MOTOR_TRACTION_ERROR_STATUS: PayloadFormat("<BB", ["motor_right", "motor_left"], "error_bits"),
+    MsgType.MOTOR_ARM_ERROR_STATUS: PayloadFormat("<BBBBBBB", [
+        "mot_1L", "mot_1R", "mot_2", "mot_3", "mot_4", "mot_5", "mot_6"
+    ], "error_bits"),
+
+    # Traction control (no payload)
+    MsgType.MOTOR_TRACTION_REBOOT: PayloadFormat("", [], ""),
+
+    # IMU raw data (debug)
+    MsgType.IMU_RAW_ACCEL: PayloadFormat("<fff", ["ax", "ay", "az"], "g"),
+    MsgType.IMU_RAW_GYRO: PayloadFormat("<fff", ["gx", "gy", "gz"], "dps"),
+
+    # End effector — MK1 legacy
+    MsgType.DATA_EE_PITCH_SETPOINT: PayloadFormat("<i", ["position"], "DU"),
+    MsgType.DATA_EE_PITCH_FEEDBACK: PayloadFormat("<i", ["position"], "DU"),
+    MsgType.DATA_EE_HEAD_PITCH_SETPOINT: PayloadFormat("<i", ["position"], "DU"),
+    MsgType.DATA_EE_HEAD_PITCH_FEEDBACK: PayloadFormat("<i", ["position"], "DU"),
+    MsgType.DATA_EE_HEAD_ROLL_SETPOINT: PayloadFormat("<i", ["position"], "DU"),
+    MsgType.DATA_EE_HEAD_ROLL_FEEDBACK: PayloadFormat("<i", ["position"], "DU"),
+}
+
+
+# ─── CAN ID encoding / decoding ─────────────────────────────────────────────
+
+def encode_can_id(
+    source: int,
+    destination: int,
+    msg_type: int,
+) -> int:
+    """Build a 29-bit Extended CAN identifier.
+
+    Layout (little-endian byte view):
+        byte0 = source address  [bits 0:7]
+        byte1 = destination     [bits 8:15]
+        byte2 = msg_type (PF)   [bits 16:23]
+        byte3 = 0               [bits 24:28]
+    """
+    return (msg_type << 16) | (destination << 8) | source
+
+
+@dataclass
+class DecodedID:
+    """Parsed fields from a 29-bit CAN identifier."""
+    raw: int
+    source: int
+    destination: int
+    msg_type: int
+    source_name: str
+    destination_name: str
+    msg_name: str
+
+
+def decode_can_id(can_id: int) -> DecodedID:
+    """Parse a 29-bit Extended CAN identifier into its component fields."""
+    source = can_id & 0xFF
+    destination = (can_id >> 8) & 0xFF
+    msg_type = (can_id >> 16) & 0xFF
+
+    return DecodedID(
+        raw=can_id,
+        source=source,
+        destination=destination,
+        msg_type=msg_type,
+        source_name=MODULE_NAMES.get(source, f"0x{source:02X}"),
+        destination_name=MODULE_NAMES.get(destination, f"0x{destination:02X}"),
+        msg_name=MSG_NAMES.get(msg_type, f"UNKNOWN_0x{msg_type:02X}"),
+    )

--- a/tools/can_tester/requirements.txt
+++ b/tools/can_tester/requirements.txt
@@ -1,0 +1,3 @@
+python-can>=4.0
+flask>=3.0
+gs_usb>=0.3

--- a/tools/can_tester/sender.py
+++ b/tools/can_tester/sender.py
@@ -10,8 +10,12 @@ import can
 import time
 from typing import Optional
 
-from .protocol import MsgType, ModuleAddress, encode_can_id
-from .codec import encode_payload
+try:
+    from .protocol import MsgType, ModuleAddress, encode_can_id
+    from .codec import encode_payload
+except ImportError:
+    from protocol import MsgType, ModuleAddress, encode_can_id
+    from codec import encode_payload
 
 
 class CanSender:
@@ -144,3 +148,27 @@ class CanSender:
         """Emergency stop: zero all motor speeds."""
         for dest in [ModuleAddress.MK2_MOD1, ModuleAddress.MK2_MOD2, ModuleAddress.MK2_MOD3]:
             self.traction(0.0, 0.0, dest)
+
+    def torque_enable(
+        self,
+        torque_bitfield: int,
+        destination: int = ModuleAddress.MK2_MOD1,
+    ) -> None:
+        """Enable/disable torque for individual motors via bitfield.
+
+        Bit layout (uint16):
+          bit 0  = right traction motor
+          bit 1  = left traction motor
+          bit 2  = arm/joint motor 1 (J1a / joint-left)
+          bit 3  = arm/joint motor 2 (J1b / joint-right)
+          bit 4  = arm/joint motor 3 (J2 / joint-roll)
+          bit 5  = arm motor 4 (J3)
+          bit 6  = arm motor 5 (J4)
+          bit 7  = arm motor 6 (J5)
+          bits 8-15 = unused
+
+        Args:
+            torque_bitfield: uint16 bitmask, 1=enable torque, 0=disable.
+            destination: Target module address.
+        """
+        self.send(MsgType.TORQUE_ENABLE_DISABLE, destination, torque_bitfield=torque_bitfield)

--- a/tools/can_tester/sender.py
+++ b/tools/can_tester/sender.py
@@ -1,0 +1,146 @@
+"""
+CAN message sender with convenience methods for STM32LowLevel commands.
+
+Wraps python-can's Bus object and provides typed, protocol-aware send methods.
+"""
+
+from __future__ import annotations
+
+import can
+import time
+from typing import Optional
+
+from .protocol import MsgType, ModuleAddress, encode_can_id
+from .codec import encode_payload
+
+
+class CanSender:
+    """Send CAN messages to STM32LowLevel modules."""
+
+    def __init__(
+        self,
+        bus: can.BusABC,
+        source: int = ModuleAddress.CENTRAL,
+    ):
+        self.bus = bus
+        self.source = source
+
+    def send_raw(
+        self,
+        msg_type: int,
+        data: bytes,
+        destination: int = ModuleAddress.MK2_MOD1,
+    ) -> None:
+        """Send a raw CAN message."""
+        can_id = encode_can_id(self.source, destination, msg_type)
+        msg = can.Message(
+            arbitration_id=can_id,
+            data=data,
+            is_extended_id=True,
+            is_fd=True,
+            bitrate_switch=True,
+        )
+        self.bus.send(msg)
+
+    def send(
+        self,
+        msg_type: int,
+        destination: int = ModuleAddress.MK2_MOD1,
+        **kwargs,
+    ) -> None:
+        """Encode and send a CAN message.
+
+        Args:
+            msg_type: MsgType value.
+            destination: Target module address.
+            **kwargs: Payload fields matching the PayloadFormat.
+        """
+        data = encode_payload(msg_type, **kwargs)
+        self.send_raw(msg_type, data, destination)
+
+    # ─── Convenience methods ─────────────────────────────────────────────
+
+    def traction(
+        self,
+        left_rpm: float,
+        right_rpm: float,
+        destination: int = ModuleAddress.MK2_MOD1,
+    ) -> None:
+        """Set traction motor speeds."""
+        self.send(
+            MsgType.MOTOR_SETPOINT,
+            destination,
+            right_rpm=right_rpm,
+            left_rpm=left_rpm,
+        )
+
+    def arm_pitch_1a1b(self, theta: float, phi: float) -> None:
+        """Set arm J1 differential pitch/yaw."""
+        self.send(MsgType.ARM_PITCH_1a1b_SETPOINT, theta=theta, phi=phi)
+
+    def arm_pitch_j2(self, angle: float) -> None:
+        """Set arm elbow pitch J2."""
+        self.send(MsgType.ARM_PITCH_2_SETPOINT, angle=angle)
+
+    def arm_roll_j3(self, angle: float) -> None:
+        """Set arm roll J3."""
+        self.send(MsgType.ARM_ROLL_3_SETPOINT, angle=angle)
+
+    def arm_pitch_j4(self, angle: float) -> None:
+        """Set arm wrist pitch J4."""
+        self.send(MsgType.ARM_PITCH_4_SETPOINT, angle=angle)
+
+    def arm_roll_j5(self, angle: float) -> None:
+        """Set arm wrist roll J5."""
+        self.send(MsgType.ARM_ROLL_5_SETPOINT, angle=angle)
+
+    def arm_beak(self, close: bool) -> None:
+        """Control beak gripper. close=True to close, False to open."""
+        # Firmware convention: 0 = close, 1 = open
+        self.send(MsgType.ARM_ROLL_6_SETPOINT, command=0 if close else 1)
+
+    def reset_arm(self) -> None:
+        """Move arm to calibrated initial position."""
+        self.send(MsgType.RESET_ARM)
+
+    def reboot_arm(self) -> None:
+        """Reboot all arm Dynamixel motors."""
+        self.send(MsgType.REBOOT_ARM)
+
+    def set_home(self, persist: bool = False) -> None:
+        """Set current arm position as home. persist=True saves to flash."""
+        self.send(MsgType.SET_HOME, persist=1 if persist else 0)
+
+    def reboot_traction(
+        self,
+        destination: int = ModuleAddress.MK2_MOD1,
+    ) -> None:
+        """Reboot traction Dynamixel motors."""
+        self.send(MsgType.MOTOR_TRACTION_REBOOT, destination)
+
+    def joint_pitch_1a1b(
+        self,
+        theta: float,
+        phi: float,
+        destination: int = ModuleAddress.MK2_MOD2,
+    ) -> None:
+        """Set inter-module joint differential pitch/yaw."""
+        self.send(
+            MsgType.JOINT_PITCH_1a1b_SETPOINT,
+            destination,
+            theta=theta,
+            phi=phi,
+        )
+
+    def joint_roll(
+        self,
+        angle: float,
+        destination: int = ModuleAddress.MK2_MOD2,
+    ) -> None:
+        """Set inter-module joint roll."""
+        self.send(MsgType.JOINT_ROLL_2_SETPOINT, destination, angle=angle)
+
+    def stop_all(self) -> None:
+        """Emergency stop: zero all motor speeds."""
+        for dest in [ModuleAddress.MK2_MOD1, ModuleAddress.MK2_MOD2, ModuleAddress.MK2_MOD3]:
+            self.traction(0.0, 0.0, dest)

--- a/tools/can_tester/test_dry.py
+++ b/tools/can_tester/test_dry.py
@@ -1,0 +1,133 @@
+"""Dry test — validates all CAN tester logic without hardware."""
+
+import sys
+
+def main():
+    errors = 0
+
+    # 1. Import test
+    print("=== Import test ===")
+    try:
+        from tools.can_tester import (
+            protocol, codec, sender, monitor, cli,
+            test_sequences, web_dashboard, header_parser,
+        )
+        print("  All modules imported OK")
+    except Exception as e:
+        print(f"  FAIL: {e}")
+        errors += 1
+        sys.exit(1)
+
+    # 2. CAN ID encode/decode
+    print("\n=== CAN ID encode/decode ===")
+    from tools.can_tester.protocol import (
+        encode_can_id, decode_can_id, MsgType, ModuleAddress,
+    )
+
+    can_id = encode_can_id(
+        ModuleAddress.CENTRAL, ModuleAddress.MK2_MOD1,
+        MsgType.ARM_PITCH_2_SETPOINT,
+    )
+    print(f"  encode(CENTRAL -> MK2_MOD1, ARM_PITCH_2_SETPOINT) = 0x{can_id:08X}")
+
+    decoded = decode_can_id(can_id)
+    assert decoded.source == ModuleAddress.CENTRAL, f"src mismatch: {decoded.source}"
+    assert decoded.destination == ModuleAddress.MK2_MOD1, f"dst mismatch: {decoded.destination}"
+    assert decoded.msg_type == MsgType.ARM_PITCH_2_SETPOINT, f"msg mismatch: {decoded.msg_type}"
+    print(f"  decode -> {decoded.source_name} -> {decoded.destination_name}: {decoded.msg_name}")
+    print("  Round-trip OK")
+
+    # 3. Payload codec
+    print("\n=== Payload codec ===")
+    from tools.can_tester.codec import encode_payload, decode_payload, format_decoded
+    from tools.can_tester.protocol import PAYLOAD_FORMATS, DecodedID
+
+    # Test traction motor setpoint (two floats: right_rpm, left_rpm)
+    data = encode_payload(MsgType.MOTOR_SETPOINT, right_rpm=100.0, left_rpm=-50.0)
+    vals = decode_payload(MsgType.MOTOR_SETPOINT, data)
+    assert abs(vals["right_rpm"] - 100.0) < 0.01, f"right_rpm mismatch: {vals}"
+    assert abs(vals["left_rpm"] - (-50.0)) < 0.01, f"left_rpm mismatch: {vals}"
+    print(f"  MOTOR_SETPOINT encode -> {data.hex()} -> {vals} OK")
+
+    # Test arm single float
+    data2 = encode_payload(MsgType.ARM_PITCH_2_SETPOINT, angle=1.5708)
+    vals2 = decode_payload(MsgType.ARM_PITCH_2_SETPOINT, data2)
+    assert abs(vals2["angle"] - 1.5708) < 0.001, f"arm mismatch: {vals2}"
+    print(f"  ARM_PITCH_2_SETPOINT encode -> {data2.hex()} -> OK")
+
+    # Test no-payload messages
+    data3 = encode_payload(MsgType.RESET_ARM)
+    assert data3 == b"", f"RESET_ARM should be empty: {data3}"
+    vals3 = decode_payload(MsgType.RESET_ARM, data3)
+    assert vals3 == {}, f"RESET_ARM decode should be empty: {vals3}"
+    print(f"  RESET_ARM (no payload) OK")
+
+    # Test format_decoded
+    test_id = decode_can_id(encode_can_id(
+        ModuleAddress.CENTRAL, ModuleAddress.MK2_MOD1, MsgType.MOTOR_SETPOINT
+    ))
+    fmt = format_decoded(test_id, vals)
+    print(f"  format_decoded: {fmt}")
+
+    # 4. Header parser — STM32LowLevel MK2 module variants
+    print("\n=== Module config variants ===")
+    for variant in ["MK2_MOD1", "MK2_MOD2", "MK2_MOD3"]:
+        defs = header_parser.parse_mod_config(variant)
+        can_id_val = defs.get("CAN_ID", 0)
+        print(f"  {variant}: CAN_ID=0x{can_id_val:02X}, {len(defs)} defines")
+        assert "CAN_ID" in defs, f"{variant} missing CAN_ID"
+
+    # Verify CAN_ID values match expected module addresses
+    assert header_parser.parse_mod_config("MK2_MOD1")["CAN_ID"] == 0x21, \
+        "MK2_MOD1 CAN_ID should be 0x21"
+    assert header_parser.parse_mod_config("MK2_MOD2")["CAN_ID"] == 0x22, \
+        "MK2_MOD2 CAN_ID should be 0x22"
+    assert header_parser.parse_mod_config("MK2_MOD3")["CAN_ID"] == 0x23, \
+        "MK2_MOD3 CAN_ID should be 0x23"
+    print("  CAN_ID values OK")
+
+    # Verify conditional exclusion: MK2_MOD1 should have ARM servo IDs, not JOINT
+    mk2_1 = header_parser.parse_mod_config("MK2_MOD1")
+    assert "SERVO_ARM_2_PITCH_ID" in mk2_1, "MK2_MOD1 missing SERVO_ARM_2_PITCH_ID"
+    print("  MK2_MOD1 servo defines OK")
+
+    # Verify MK2_MOD2/3 do not have arm servo IDs (only joint + yaw)
+    mk2_2 = header_parser.parse_mod_config("MK2_MOD2")
+    assert "SERVO_ARM_2_PITCH_ID" not in mk2_2, "MK2_MOD2 should not have ARM servo IDs"
+    print("  MK2_MOD2 conditional isolation OK")
+
+    # 5. Test sequences — verify importable
+    print("\n=== Test sequences ===")
+    from tools.can_tester import test_sequences
+    seq_funcs = [
+        name for name in dir(test_sequences)
+        if name.startswith("test_") and callable(getattr(test_sequences, name))
+    ]
+    for name in seq_funcs:
+        print(f"  {name}")
+    assert len(seq_funcs) >= 5, f"Expected >= 5 test functions, got {len(seq_funcs)}"
+    print(f"  {len(seq_funcs)} test functions OK")
+
+    # 6. MsgType completeness — STM32LowLevel has 44 message types
+    print(f"\n=== MsgType enum ===")
+    msg_count = len(list(MsgType))
+    print(f"  {msg_count} message types loaded")
+    assert msg_count == 44, f"Expected 44 message types, got {msg_count}"
+
+    # Spot-check key entries
+    assert MsgType.REBOOT_ARM == 0x5E
+    assert MsgType.ARM_ROLL_6_FEEDBACK_VEL == 0x85
+    assert MsgType.MOTOR_SETPOINT == 0x21
+    assert MsgType.IMU_RAW_GYRO == 0x93
+    print("  Spot checks OK")
+
+    print(f"\n{'='*40}")
+    if errors == 0:
+        print("All tests PASSED!")
+    else:
+        print(f"{errors} test(s) FAILED")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/can_tester/test_sequences.py
+++ b/tools/can_tester/test_sequences.py
@@ -1,0 +1,211 @@
+"""
+Pre-built test sequences for STM32LowLevel CAN bus validation.
+
+Each test function takes a CanSender and CanMonitor and runs a scripted
+sequence of commands, printing results.
+"""
+
+from __future__ import annotations
+
+import time
+import math
+from typing import Optional
+
+from .protocol import MsgType, ModuleAddress
+from .sender import CanSender
+from .monitor import CanMonitor, FILTER_ARM, FILTER_TRACTION
+
+
+def test_traction_basic(
+    sender: CanSender,
+    destination: int = ModuleAddress.MK2_MOD1,
+    speed: float = 5.0,
+    duration: float = 3.0,
+) -> None:
+    """Basic traction motor test: forward → stop → reverse → stop.
+
+    Args:
+        sender: CanSender instance.
+        destination: Module to test.
+        speed: RPM value to use.
+        duration: Seconds per phase.
+    """
+    print(f"=== Traction motor test (speed={speed} RPM, {duration}s per phase) ===")
+
+    print(f"  Forward ({speed} RPM)...")
+    sender.traction(speed, speed, destination)
+    time.sleep(duration)
+
+    print("  Stop...")
+    sender.traction(0.0, 0.0, destination)
+    time.sleep(1.0)
+
+    print(f"  Reverse ({-speed} RPM)...")
+    sender.traction(-speed, -speed, destination)
+    time.sleep(duration)
+
+    print("  Stop...")
+    sender.traction(0.0, 0.0, destination)
+    print("=== Traction test complete ===\n")
+
+
+def test_traction_differential(
+    sender: CanSender,
+    destination: int = ModuleAddress.MK2_MOD1,
+    speed: float = 5.0,
+    duration: float = 2.0,
+) -> None:
+    """Differential traction test: left → right → spin.
+
+    Args:
+        sender: CanSender instance.
+        destination: Module to test.
+        speed: RPM value.
+        duration: Seconds per phase.
+    """
+    print(f"=== Differential traction test ===")
+
+    print(f"  Turn left (right={speed}, left=0)...")
+    sender.traction(0.0, speed, destination)
+    time.sleep(duration)
+
+    print(f"  Turn right (right=0, left={speed})...")
+    sender.traction(speed, 0.0, destination)
+    time.sleep(duration)
+
+    print(f"  Spin (right={speed}, left={-speed})...")
+    sender.traction(-speed, speed, destination)
+    time.sleep(duration)
+
+    print("  Stop...")
+    sender.traction(0.0, 0.0, destination)
+    print("=== Differential test complete ===\n")
+
+
+def test_arm_init(sender: CanSender) -> None:
+    """Test arm initialization: reset → verify feedback.
+
+    Sends RESET_ARM and waits for feedback messages.
+    """
+    print("=== Arm initialization test ===")
+
+    print("  Sending RESET_ARM...")
+    sender.reset_arm()
+    time.sleep(3.0)
+
+    print("  Arm should now be at home position.")
+    print("  Check feedback messages for position confirmation.")
+    print("=== Arm init test complete ===\n")
+
+
+def test_arm_joints(
+    sender: CanSender,
+    amplitude: float = 0.2,
+    duration: float = 2.0,
+) -> None:
+    """Move each arm joint individually by a small amount.
+
+    Args:
+        sender: CanSender instance.
+        amplitude: Angle in radians to move each joint.
+        duration: Seconds to wait between movements.
+    """
+    print(f"=== Arm joint test (amplitude={amplitude} rad) ===")
+
+    joints = [
+        ("J1 (pitch 1a1b)", lambda a: sender.arm_pitch_1a1b(a, 0.0)),
+        ("J2 (elbow pitch)", sender.arm_pitch_j2),
+        ("J3 (roll)", sender.arm_roll_j3),
+        ("J4 (wrist pitch)", sender.arm_pitch_j4),
+        ("J5 (wrist roll)", sender.arm_roll_j5),
+    ]
+
+    for name, cmd in joints:
+        print(f"  Moving {name} to +{amplitude} rad...")
+        cmd(amplitude)
+        time.sleep(duration)
+
+        print(f"  Moving {name} to 0 rad...")
+        cmd(0.0)
+        time.sleep(duration)
+
+    print("=== Arm joint test complete ===\n")
+
+
+def test_arm_beak(sender: CanSender, wait: float = 3.0) -> None:
+    """Test beak open/close cycle.
+
+    Args:
+        sender: CanSender instance.
+        wait: Seconds to wait between open/close.
+    """
+    print("=== Beak gripper test ===")
+
+    print("  Closing beak...")
+    sender.arm_beak(close=True)
+    time.sleep(wait)
+
+    print("  Opening beak...")
+    sender.arm_beak(close=False)
+    time.sleep(wait)
+
+    print("=== Beak test complete ===\n")
+
+
+def test_arm_reboot(sender: CanSender) -> None:
+    """Test arm motor reboot sequence.
+
+    Sends REBOOT_ARM and waits for re-initialization.
+    """
+    print("=== Arm reboot test ===")
+
+    print("  Sending REBOOT_ARM...")
+    sender.reboot_arm()
+    print("  Waiting for re-initialization (5s)...")
+    time.sleep(5.0)
+
+    print("  Arm should have re-initialized smoothly.")
+    print("=== Arm reboot test complete ===\n")
+
+
+def test_full_diagnostics(
+    sender: CanSender,
+    monitor: CanMonitor,
+    speed: float = 3.0,
+) -> None:
+    """Run full diagnostic sequence: traction → arm init → arm joints → beak.
+
+    Args:
+        sender: CanSender instance.
+        monitor: CanMonitor instance (for collecting feedback).
+        speed: RPM for traction tests.
+    """
+    print("=" * 60)
+    print("  FULL DIAGNOSTICS")
+    print("=" * 60)
+
+    test_traction_basic(sender, speed=speed, duration=2.0)
+    test_arm_init(sender)
+    test_arm_joints(sender, amplitude=0.15, duration=1.5)
+    test_arm_beak(sender, wait=2.0)
+
+    print("=" * 60)
+    print("  DIAGNOSTICS COMPLETE")
+    print("=" * 60)
+
+    print("\nFeedback summary:")
+    for name, count in monitor.stats.items():
+        print(f"  {name}: {count} messages")
+
+
+# ─── Test registry ───────────────────────────────────────────────────────────
+
+TESTS = {
+    "traction": test_traction_basic,
+    "traction_diff": test_traction_differential,
+    "arm_init": test_arm_init,
+    "arm_joints": test_arm_joints,
+    "arm_beak": test_arm_beak,
+    "arm_reboot": test_arm_reboot,
+    "full": test_full_diagnostics,
+}

--- a/tools/can_tester/web_dashboard.py
+++ b/tools/can_tester/web_dashboard.py
@@ -22,14 +22,20 @@ import threading
 import time
 from queue import Queue, Empty, Full
 
-from flask import Flask, Response, request, jsonify, render_template_string
+from flask import Flask, Response, request, jsonify, render_template_string, make_response
 
 import can
 
-from .protocol import ModuleAddress, MsgType, decode_can_id, MSG_NAMES
-from .codec import decode_payload, format_decoded
-from .sender import CanSender
-from .monitor import CanMonitor, NAMED_FILTERS
+try:
+    from .protocol import ModuleAddress, MsgType, encode_can_id, decode_can_id, MSG_NAMES
+    from .codec import encode_payload, decode_payload, format_decoded
+    from .sender import CanSender
+    from .monitor import CanMonitor, NAMED_FILTERS
+except ImportError:
+    from protocol import ModuleAddress, MsgType, encode_can_id, decode_can_id, MSG_NAMES
+    from codec import encode_payload, decode_payload, format_decoded
+    from sender import CanSender
+    from monitor import CanMonitor, NAMED_FILTERS
 
 app = Flask(__name__)
 
@@ -39,6 +45,17 @@ sender: CanSender = None  # type: ignore
 monitor: CanMonitor = None  # type: ignore
 event_queues: list[Queue] = []
 event_queues_lock = threading.Lock()
+
+# Track last received message for status endpoint
+_last_recv_msg = None
+_last_recv_lock = threading.Lock()
+
+# Message buffer for polling endpoint
+_msg_buffer = []
+_msg_buffer_lock = threading.Lock()
+_msg_id_counter = 0
+
+
 
 # Accumulated positions for relative mode (per-command)
 _positions: dict[str, list[float]] = {}
@@ -106,6 +123,7 @@ h2 { color: var(--blue); margin-bottom: 8px; font-size: 1.1rem; }
       <button data-filter="traction">Traction</button>
       <button data-filter="joint">Joint</button>
       <button data-filter="imu">IMU</button>
+      <button data-filter="battery">Battery</button>
       <button data-filter="feedback">Feedback</button>
       <button id="pauseBtn" onclick="togglePause()" style="margin-left:12px">⏸ Pause</button>
     </div>
@@ -139,8 +157,23 @@ h2 { color: var(--blue); margin-bottom: 8px; font-size: 1.1rem; }
             <input id="val2" type="number" step="1" value="0" style="width:140px">
           </div>
         </div>
-        <button onclick="sendCmd()">Send</button>
+        <button onclick="sendCommand()">Send</button>
         <button class="danger" onclick="stopAll()">STOP ALL</button>
+      </div>
+      <div id="torqueDropdowns" style="display:none;margin-top:8px">
+        <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+          <div style="display:flex;flex-direction:column;gap:2px">
+            <label style="font-size:0.75rem;color:var(--green)">Motor</label>
+            <select id="torqueMotor" style="width:200px"></select>
+          </div>
+          <div style="display:flex;flex-direction:column;gap:2px">
+            <label style="font-size:0.75rem;color:var(--green)">State</label>
+            <select id="torqueState" style="width:160px">
+              <option value="1">ON (enable torque)</option>
+              <option value="0">OFF (disable torque)</option>
+            </select>
+          </div>
+        </div>
       </div>
       <div id="cmdOptions" style="margin-top:8px;display:none">
         <label style="font-size:0.8rem;color:var(--green);cursor:pointer">
@@ -168,9 +201,6 @@ h2 { color: var(--blue); margin-bottom: 8px; font-size: 1.1rem; }
         </div>
       </div>
       <div style="margin-top:12px;border-top:1px solid rgba(255,255,255,0.1);padding-top:8px">
-        <label style="font-size:0.8rem;color:var(--blue);cursor:pointer" onclick="document.getElementById('seqPanel').style.display=document.getElementById('seqPanel').style.display==='none'?'':'none'">
-          Sequence Builder <span style="font-size:0.7rem">(click to expand)</span>
-        </label>
         <div id="seqPanel" style="display:none;margin-top:8px">
           <p style="font-size:0.75rem;color:#888;margin-bottom:6px">Build a sequence of commands with different parameters. Click "Add Current" to add the current command/params to the sequence.</p>
           <div style="display:flex;gap:4px;margin-bottom:8px">
@@ -238,6 +268,7 @@ const CMDS_ARM = [
     { val: 'set_home', label: 'Set Home — Save current position as home' },
   ]},
   { group: 'System', items: [
+    { val: 'torque', label: 'Torque Enable/Disable — Per-motor torque control (bitfield)' },
     { val: 'reboot_traction', label: 'Reboot Traction — Restart DC motors' },
     { val: 'stop_all', label: 'Emergency Stop — Zero all motors' },
   ]},
@@ -252,6 +283,7 @@ const CMDS_JOINT = [
     { val: 'joint_roll', label: 'Joint Roll — Axial rotation' },
   ]},
   { group: 'System', items: [
+    { val: 'torque', label: 'Torque Enable/Disable — Per-motor torque control (bitfield)' },
     { val: 'reboot_traction', label: 'Reboot Traction — Restart DC motors' },
     { val: 'stop_all', label: 'Emergency Stop — Zero all motors' },
   ]},
@@ -278,11 +310,37 @@ const CMD_INFO = {
   set_home:   { desc: 'Set current arm position as new home. Check "Permanent" to persist across power cycles.', lbl1: '', lbl2: '', inputs: 0, step: 1, hasOptions: true },
   reboot_traction: { desc: 'Reboot traction DC motors. Sends a reboot command to the traction controller.', lbl1: '', lbl2: '', inputs: 0, step: 1 },
   stop_all:   { desc: 'Emergency stop — sends zero speed to all traction motors on all modules.', lbl1: '', lbl2: '', inputs: 0, step: 1 },
+  torque:     { desc: 'Enable or disable torque for a single motor.',
+                 lbl1: 'Motor', lbl2: 'State', inputs: 'torque', step: 1 },
   joint_1a1b: { desc: 'Set inter-module joint differential pitch/yaw. Theta controls yaw, phi controls pitch. Range: approx -1.57 to 1.57 rad.',
                  lbl1: 'Theta / Yaw (rad)', lbl2: 'Phi / Pitch (rad)', inputs: 2, step: 0.05 },
   joint_roll: { desc: 'Set inter-module joint axial roll. Range: approx -3.14 to 3.14 rad.',
                  lbl1: 'Angle (rad)', lbl2: '', inputs: 1, step: 0.05 },
 };
+
+// Motor options for torque command — per module type
+// Each entry: { bit: <bit number>, name: <human readable> }
+const TORQUE_MOTORS_ARM = [
+  { bit: 0, name: 'Right Traction' },
+  { bit: 1, name: 'Left Traction' },
+  { bit: 2, name: 'Arm J1a (Shoulder Pitch)' },
+  { bit: 3, name: 'Arm J1b (Shoulder Yaw)' },
+  { bit: 4, name: 'Arm J2 (Elbow Pitch)' },
+  { bit: 5, name: 'Arm J3 (Forearm Roll)' },
+  { bit: 6, name: 'Arm J4 (Wrist Pitch)' },
+  { bit: 7, name: 'Arm J5 (Wrist Roll)' },
+];
+const TORQUE_MOTORS_JOINT = [
+  { bit: 0, name: 'Right Traction' },
+  { bit: 1, name: 'Left Traction' },
+  { bit: 2, name: 'Joint J1-Left (Pitch)' },
+  { bit: 3, name: 'Joint J1-Right (Yaw)' },
+  { bit: 4, name: 'Joint J2 (Roll)' },
+];
+const TORQUE_STATES = [
+  { val: 1, label: 'ON (enable torque)' },
+  { val: 0, label: 'OFF (disable torque)' },
+];
 
 // Build command dropdown based on selected module
 function rebuildCommandDropdown() {
@@ -305,9 +363,13 @@ function rebuildCommandDropdown() {
   // Try to preserve previous selection
   if ([...sel.options].some(o => o.value === prev)) sel.value = prev;
   updateForm();
+  rebuildTorqueMotors();
 }
 
-document.getElementById('targetModule').addEventListener('change', rebuildCommandDropdown);
+document.getElementById('targetModule').addEventListener('change', function() {
+  rebuildCommandDropdown();
+  rebuildTorqueMotors();
+});
 
 function updateForm() {
   const cmd = document.getElementById('cmdType').value;
@@ -320,18 +382,31 @@ function updateForm() {
   const v1 = document.getElementById('val1');
   const v2 = document.getElementById('val2');
   const group = document.getElementById('inputGroup');
-  l1.textContent = info.lbl1;
-  l2.textContent = info.lbl2;
-  v1.step = info.step || 1;
-  v2.step = info.step || 1;
-  f1.style.display = info.inputs >= 1 ? '' : 'none';
-  f2.style.display = info.inputs >= 2 ? '' : 'none';
-  group.style.display = info.inputs > 0 ? '' : 'none';
+  const torqueDropdowns = document.getElementById('torqueDropdowns');
+
+  if (info.inputs === 'torque') {
+    // Show torque dropdowns, hide normal inputs
+    group.style.display = 'none';
+    if (torqueDropdowns) torqueDropdowns.style.display = '';
+  } else {
+    // Show normal inputs, hide torque dropdowns
+    l1.textContent = info.lbl1;
+    l2.textContent = info.lbl2;
+    v1.step = info.step || 1;
+    v2.step = info.step || 1;
+    f1.style.display = info.inputs >= 1 ? '' : 'none';
+    f2.style.display = info.inputs >= 2 ? '' : 'none';
+    group.style.display = info.inputs > 0 ? '' : 'none';
+    if (torqueDropdowns) torqueDropdowns.style.display = 'none';
+  }
   // Show permanent checkbox for set_home
   document.getElementById('cmdOptions').style.display = info.hasOptions ? '' : 'none';
   // Show relative mode for arm/joint angle commands
   const isAngle = cmd.startsWith('arm_') || cmd.startsWith('joint_');
   document.getElementById('relativeMode').style.display = (isAngle && info.inputs > 0) ? '' : 'none';
+  // Show torque quick-preset buttons
+  const torquePresets = document.getElementById('torquePresets');
+  if (torquePresets) torquePresets.style.display = (cmd === 'torque') ? '' : 'none';
 }
 rebuildCommandDropdown();  // set initial state
 
@@ -365,30 +440,45 @@ function markConnected() {
   }, 5000);
 }
 
-// SSE
-function connect() {
-  const es = new EventSource('/stream');
-  es.onopen = () => {
-    // SSE channel open — but don't show "connected" until we get CAN data
-  };
-  es.onmessage = e => {
-    const d = JSON.parse(e.data);
-    markConnected();
-    const typeHex = '0x' + d.msg_type.toString(16).toUpperCase().padStart(2, '0');
-    const key = d.msg_name + ' [' + typeHex + ']';
-    stats[key] = (stats[key] || 0) + 1;
-    latestValues[d.msg_name] = d.payload_str;
-    msgBuffer.push({...d, typeHex});
-    dirty = true;
-  };
-  es.onerror = () => {
-    document.getElementById('connDot').className = 'status-dot off';
-    document.getElementById('connText').textContent = 'SSE disconnected — reconnecting...';
-    es.close();
-    setTimeout(connect, 2000);
-  };
+// Poll for new CAN messages
+let lastMsgId = 0;
+let pollInterval = null;
+
+function startPolling() {
+  if (pollInterval) return;
+  pollInterval = setInterval(fetchMessages, 200);
 }
-connect();
+
+function stopPolling() {
+  if (pollInterval) {
+    clearInterval(pollInterval);
+    pollInterval = null;
+  }
+}
+
+async function fetchMessages() {
+  try {
+    const r = await fetch('/messages?since=' + lastMsgId);
+    if (!r.ok) return;
+    const data = await r.json();
+    if (!data.messages || data.messages.length === 0) return;
+    for (const d of data.messages) {
+      lastMsgId = Math.max(lastMsgId, d._id || 0);
+      markConnected();
+      const typeHex = '0x' + d.msg_type.toString(16).toUpperCase().padStart(2, '0');
+      const key = d.msg_name + ' [' + typeHex + ']';
+      stats[key] = (stats[key] || 0) + 1;
+      latestValues[d.msg_name] = d.payload_str;
+      msgBuffer.push({...d, typeHex});
+      dirty = true;
+    }
+  } catch(e) {
+    // ignore network errors
+  }
+}
+
+// Start polling when page loads
+window.addEventListener('load', startPolling);
 
 function updateStats() {
   const body = document.getElementById('statsBody');
@@ -440,16 +530,54 @@ function sendOne(cmd, target, v1, v2, opts) {
   }).then(r => r.json()).then(d => { if(d.error) alert(d.error); });
 }
 
-function sendCmd() {
+// ── Torque bitfield state tracking ──
+// Tracks the current bitfield per module so we can toggle individual motors
+const torqueState = { '0x21': 0xFF, '0x22': 0xFF, '0x23': 0xFF }; // Start all enabled
+
+// Populate torque motor dropdown based on selected module
+function rebuildTorqueMotors() {
+  const mod = document.getElementById('targetModule').value;
+  const isArm = mod === '0x21';
+  const motors = isArm ? TORQUE_MOTORS_ARM : TORQUE_MOTORS_JOINT;
+  const sel = document.getElementById('torqueMotor');
+  if (!sel) return;
+  sel.innerHTML = '';
+  motors.forEach(m => {
+    const o = document.createElement('option');
+    o.value = m.bit; o.textContent = m.name;
+    sel.appendChild(o);
+  });
+}
+
+function sendCommand() {
   const cmd = document.getElementById('cmdType').value;
   const target = parseInt(document.getElementById('targetModule').value);
-  const v1 = parseFloat(document.getElementById('val1').value) || 0;
-  const v2 = parseFloat(document.getElementById('val2').value) || 0;
   const count = parseInt(document.getElementById('burstCount').value) || 1;
   const interval = parseInt(document.getElementById('burstInterval').value) || 100;
   const opts = {};
-  if (document.getElementById('optPermanent').checked) opts.permanent = true;
-  if (document.getElementById('optRelative').checked) opts.relative = true;
+  if (document.getElementById('optPermanent')) {
+    if (document.getElementById('optPermanent').checked) opts.permanent = true;
+  }
+  if (document.getElementById('optRelative')) {
+    if (document.getElementById('optRelative').checked) opts.relative = true;
+  }
+
+  let v1, v2;
+  if (cmd === 'torque') {
+    const motorBit = parseInt(document.getElementById('torqueMotor').value) || 0;
+    const state = parseInt(document.getElementById('torqueState').value) || 0;
+    const targetHex = '0x' + target.toString(16);
+    if (state) {
+      torqueState[targetHex] |= (1 << motorBit);
+    } else {
+      torqueState[targetHex] &= ~(1 << motorBit);
+    }
+    v1 = torqueState[targetHex];
+    v2 = 0;
+  } else {
+    v1 = parseFloat(document.getElementById('val1').value) || 0;
+    v2 = parseFloat(document.getElementById('val2').value) || 0;
+  }
 
   if (count <= 1) { sendOne(cmd, target, v1, v2, opts); return; }
 
@@ -568,8 +696,31 @@ def get_filter_tags(msg_type: int) -> list[str]:
 
 @app.route("/")
 def index():
-    return render_template_string(DASHBOARD_HTML)
+    response = make_response(render_template_string(DASHBOARD_HTML))
+    response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
+    response.headers["X-Version"] = str(time.time())
+    return response
 
+
+@app.route("/status")
+def status():
+    """Return the last received CAN message for debugging."""
+    global _last_recv_msg
+    with _last_recv_lock:
+        if _last_recv_msg is None:
+            return jsonify({"status": "no_messages", "message": "No CAN messages received yet"})
+        return jsonify({"status": "ok", "last_msg": _last_recv_msg})
+
+@app.route("/messages")
+def messages():
+    """Polling endpoint: return messages since given ID."""
+    since_id = request.args.get('since', 0, type=int)
+    with _msg_buffer_lock:
+        # Return messages with _id > since_id
+        new_msgs = [m for m in _msg_buffer if m.get('_id', 0) > since_id]
+    return jsonify({"messages": new_msgs})
 
 @app.route("/stream")
 def stream():
@@ -593,7 +744,11 @@ def stream():
                 if q in event_queues:
                     event_queues.remove(q)
 
-    return Response(generate(), mimetype="text/event-stream")
+    response = Response(generate(), mimetype="text/event-stream")
+    response.headers["Cache-Control"] = "no-cache"
+    response.headers["X-Accel-Buffering"] = "no"
+    response.headers["Connection"] = "keep-alive"
+    return response
 
 
 @app.route("/send", methods=["POST"])
@@ -648,6 +803,10 @@ def send_command():
             sender.joint_pitch_1a1b(v1, v2, destination=dest)
         elif cmd == "joint_roll":
             sender.joint_roll(v1, destination=dest)
+        elif cmd == "torque":
+            # Accept hex (0x...) or decimal bitfield
+            bitfield = int(data.get("val1", 0))
+            sender.torque_enable(bitfield, destination=dest)
         elif cmd == "stop_all":
             sender.stop_all()
         else:
@@ -699,6 +858,22 @@ def can_to_sse_callback(decoded_id, payload, raw_msg):
                 q.put_nowait(event)
             except Full:
                 pass  # Drop if client is slow
+    
+    # Track last received message
+    global _last_recv_msg
+    with _last_recv_lock:
+        _last_recv_msg = event
+    
+    # Store in polling buffer
+    global _msg_id_counter
+    with _msg_buffer_lock:
+        _msg_id_counter += 1
+        event_with_id = dict(event)
+        event_with_id['_id'] = _msg_id_counter
+        _msg_buffer.append(event_with_id)
+        # Keep only last 500 messages
+        if len(_msg_buffer) > 500:
+            _msg_buffer.pop(0)
 
 
 # ─── Main ────────────────────────────────────────────────────────────────────
@@ -718,6 +893,10 @@ def main():
     parser.add_argument(
         "--demo", action="store_true",
         help="Use virtual CAN bus for GUI preview (no hardware needed)",
+    )
+    parser.add_argument(
+        "--debug", action="store_true",
+        help="Enable debug output: print received CAN messages to terminal",
     )
     args = parser.parse_args()
 
@@ -746,14 +925,90 @@ def main():
     monitor.add_callback(can_to_sse_callback)
 
     # Start CAN monitor in background thread
+    # quiet=True suppresses terminal output (use --debug to enable)
     monitor_thread = threading.Thread(
         target=monitor.run,
-        kwargs={"quiet": True},
+        kwargs={"quiet": not args.debug},
         daemon=True,
     )
     monitor_thread.start()
 
+    # Start demo message generator if in demo mode
+    if args.demo:
+        def demo_generator():
+            import random
+            import time
+            
+            print("  Demo mode: Generating test messages...")
+            time.sleep(1)  # Wait for monitor to start
+            while True:
+                try:
+                    # Generate random messages for each module
+                    for module_addr in [ModuleAddress.MK2_MOD1, ModuleAddress.MK2_MOD2, ModuleAddress.MK2_MOD3]:
+                        # Motor feedback (two floats: right_rpm, left_rpm)
+                        can_id = encode_can_id(
+                            module_addr, ModuleAddress.CENTRAL,
+                            MsgType.MOTOR_FEEDBACK
+                        )
+                        data = encode_payload(MsgType.MOTOR_FEEDBACK, right_rpm=random.uniform(-100, 100), left_rpm=random.uniform(-100, 100))
+                        
+                        decoded_id = decode_can_id(can_id)
+                        payload = decode_payload(MsgType.MOTOR_FEEDBACK, data)
+                        raw_msg = can.Message(arbitration_id=can_id, data=data, is_extended_id=True)
+                        can_to_sse_callback(decoded_id, payload, raw_msg)
+                        
+                        if args.debug:
+                            print(f"  Demo: {decoded_id.msg_name} from {decoded_id.source_name}")
+                        
+                        time.sleep(0.2)
+                        
+                        # Joint yaw feedback (one float)
+                        can_id = encode_can_id(
+                            module_addr, ModuleAddress.CENTRAL,
+                            MsgType.JOINT_YAW_FEEDBACK
+                        )
+                        data = encode_payload(MsgType.JOINT_YAW_FEEDBACK, angle=random.uniform(-180, 180))
+                        
+                        decoded_id = decode_can_id(can_id)
+                        payload = decode_payload(MsgType.JOINT_YAW_FEEDBACK, data)
+                        raw_msg = can.Message(arbitration_id=can_id, data=data, is_extended_id=True)
+                        can_to_sse_callback(decoded_id, payload, raw_msg)
+                        
+                        if args.debug:
+                            print(f"  Demo: {decoded_id.msg_name} from {decoded_id.source_name}")
+                        
+                        time.sleep(0.2)
+                        
+                        # Battery voltage
+                        can_id = encode_can_id(
+                            module_addr, ModuleAddress.CENTRAL,
+                            MsgType.BATTERY_VOLTAGE
+                        )
+                        data = encode_payload(MsgType.BATTERY_VOLTAGE, voltage=random.uniform(22.0, 29.0))
+                        
+                        decoded_id = decode_can_id(can_id)
+                        payload = decode_payload(MsgType.BATTERY_VOLTAGE, data)
+                        raw_msg = can.Message(arbitration_id=can_id, data=data, is_extended_id=True)
+                        can_to_sse_callback(decoded_id, payload, raw_msg)
+                        
+                        if args.debug:
+                            print(f"  Demo: {decoded_id.msg_name} from {decoded_id.source_name}")
+                        
+                        time.sleep(0.2)
+                    
+                    time.sleep(0.5)  # Pause between cycles
+                except Exception as e:
+                    print(f"  Demo generator error: {e}")
+                    time.sleep(1)
+        
+        demo_thread = threading.Thread(target=demo_generator, daemon=True)
+        demo_thread.start()
+
     print(f"Dashboard: http://localhost:{args.port}")
+    if args.debug:
+        print("  Debug mode: CAN messages will be printed to terminal")
+    if args.demo:
+        print("  Demo mode: Generating test messages...")
     print("Press Ctrl+C to stop.\n")
 
     try:

--- a/tools/can_tester/web_dashboard.py
+++ b/tools/can_tester/web_dashboard.py
@@ -104,6 +104,15 @@ h2 { color: var(--blue); margin-bottom: 8px; font-size: 1.1rem; }
   rgba(255,255,255,0.1); padding: 4px 10px; border-radius: 4px; cursor: pointer;
   margin-right: 4px; font-size: 0.8rem; }
 .filter-bar button.active { background: var(--green); color: var(--bg); }
+.feed-controls { display: flex; align-items: center; gap: 8px; margin-top: 6px; }
+.feed-controls input, .feed-controls select { background: var(--accent); color: var(--text);
+  border: 1px solid rgba(255,255,255,0.1); padding: 4px 8px; border-radius: 4px;
+  font-size: 0.8rem; }
+.feed-controls input::placeholder { color: #888; }
+.feed-controls button { background: var(--accent); color: var(--text);
+  border: 1px solid rgba(255,255,255,0.1); padding: 4px 8px; border-radius: 4px;
+  cursor: pointer; font-size: 0.8rem; }
+.feed-controls button:hover { background: rgba(255,255,255,0.1); }
 #latestValues table { width: 100%; border-collapse: collapse; }
 #latestValues td { padding: 4px 8px; border-bottom: 1px solid rgba(255,255,255,0.05); }
 #latestValues td:first-child { color: var(--blue); white-space: nowrap; }
@@ -122,12 +131,21 @@ h2 { color: var(--blue); margin-bottom: 8px; font-size: 1.1rem; }
       <button data-filter="arm">Arm</button>
       <button data-filter="traction">Traction</button>
       <button data-filter="joint">Joint</button>
-      <button data-filter="imu">IMU</button>
-      <button data-filter="battery">Battery</button>
-      <button data-filter="feedback">Feedback</button>
-      <button id="pauseBtn" onclick="togglePause()" style="margin-left:12px">⏸ Pause</button>
     </div>
     <div id="feed"></div>
+    <div style="display:flex;align-items:center;gap:8px;margin-top:6px">
+      <input id="filterSearch" type="text" placeholder="Search text..." style="flex:1;background:var(--accent);color:var(--text);border:1px solid rgba(255,255,255,0.1);padding:4px 8px;border-radius:4px;font-size:0.8rem" oninput="applyFilters()">
+      <input id="filterCanId" type="text" placeholder="PF hex (msg type)" title="Filter by PDU Format (message type) in hex. Exact match. Comma-separated for multiple. E.g.: 22 = Motor Feedback, 21 = Motor Setpoint, 64 = Joint Roll, 12 = Battery Voltage" style="width:160px;background:var(--accent);color:var(--text);border:1px solid rgba(255,255,255,0.1);padding:4px 8px;border-radius:4px;font-size:0.8rem;font-family:monospace" oninput="applyFilters()">
+      <button id="pauseBtn" onclick="togglePause()" title="Pause/Resume feed" style="background:var(--accent);color:var(--text);border:1px solid rgba(255,255,255,0.1);padding:4px 10px;border-radius:4px;cursor:pointer;font-size:0.8rem">⏸ Pause</button>
+      <button onclick="clearFeed()" title="Clear feed" style="background:var(--accent);color:var(--text);border:1px solid rgba(255,255,255,0.1);padding:4px 10px;border-radius:4px;cursor:pointer;font-size:0.8rem">✕ Clear</button>
+    </div>
+    <div id="moduleFilterRow" style="display:flex;align-items:center;gap:4px;margin-top:4px;flex-wrap:wrap">
+      <span style="font-size:0.75rem;color:#888;margin-right:4px">Modules:</span>
+      <button class="module-filter-btn active" data-module="" onclick="toggleModuleFilter(this)" style="background:var(--green);color:var(--bg);border:1px solid var(--green);padding:2px 8px;border-radius:4px;cursor:pointer;font-size:0.75rem">All</button>
+      <button class="module-filter-btn" data-module="0x21" onclick="toggleModuleFilter(this)" style="background:var(--accent);color:var(--text);border:1px solid rgba(255,255,255,0.1);padding:2px 8px;border-radius:4px;cursor:pointer;font-size:0.75rem">MOD1</button>
+      <button class="module-filter-btn" data-module="0x22" onclick="toggleModuleFilter(this)" style="background:var(--accent);color:var(--text);border:1px solid rgba(255,255,255,0.1);padding:2px 8px;border-radius:4px;cursor:pointer;font-size:0.75rem">MOD2</button>
+      <button class="module-filter-btn" data-module="0x23" onclick="toggleModuleFilter(this)" style="background:var(--accent);color:var(--text);border:1px solid rgba(255,255,255,0.1);padding:2px 8px;border-radius:4px;cursor:pointer;font-size:0.75rem">MOD3</button>
+    </div>
     <div style="font-size:0.75rem;color:#666;margin-top:4px" id="scrollHint"></div>
   </div>
   <div>
@@ -201,6 +219,9 @@ h2 { color: var(--blue); margin-bottom: 8px; font-size: 1.1rem; }
         </div>
       </div>
       <div style="margin-top:12px;border-top:1px solid rgba(255,255,255,0.1);padding-top:8px">
+        <label style="font-size:0.8rem;color:var(--blue);cursor:pointer" onclick="document.getElementById('seqPanel').style.display=document.getElementById('seqPanel').style.display==='none'?'':'none'">
+          Sequence Builder <span style="font-size:0.7rem">(click to expand)</span>
+        </label>
         <div id="seqPanel" style="display:none;margin-top:8px">
           <p style="font-size:0.75rem;color:#888;margin-bottom:6px">Build a sequence of commands with different parameters. Click "Add Current" to add the current command/params to the sequence.</p>
           <div style="display:flex;gap:4px;margin-bottom:8px">
@@ -231,6 +252,9 @@ h2 { color: var(--blue); margin-bottom: 8px; font-size: 1.1rem; }
 </div>
 <script>
 let activeFilter = 'all';
+let filterText = '';
+let filterModules = new Set(); // empty = all modules
+let filterCanIds = []; // empty = all CAN IDs
 const feed = document.getElementById('feed');
 const maxLines = 200;
 const stats = {};
@@ -241,6 +265,8 @@ let paused = false;
 let msgBuffer = [];
 let dirty = false;
 let burstTimer = null;
+// Store all rendered messages for retroactive filtering
+let allMessages = [];
 
 // Detect if user scrolled up — pause auto-scroll
 feed.addEventListener('scroll', () => {
@@ -416,8 +442,109 @@ document.getElementById('filterBar').addEventListener('click', e => {
     document.querySelectorAll('.filter-bar button').forEach(b => b.classList.remove('active'));
     e.target.classList.add('active');
     activeFilter = e.target.dataset.filter;
+    applyFilters();
   }
 });
+
+// Toggle module filter button (multi-select)
+function toggleModuleFilter(btn) {
+  const mod = btn.dataset.module;
+  if (mod === '') {
+    // "All" clicked — deselect everything else
+    filterModules.clear();
+    document.querySelectorAll('.module-filter-btn').forEach(b => {
+      b.style.background = 'var(--accent)';
+      b.style.color = 'var(--text)';
+      b.style.borderColor = 'rgba(255,255,255,0.1)';
+    });
+    btn.style.background = 'var(--green)';
+    btn.style.color = 'var(--bg)';
+    btn.style.borderColor = 'var(--green)';
+  } else {
+    // Toggle specific module
+    const allBtn = document.querySelector('.module-filter-btn[data-module=""]');
+    if (filterModules.has(mod)) {
+      filterModules.delete(mod);
+      btn.style.background = 'var(--accent)';
+      btn.style.color = 'var(--text)';
+      btn.style.borderColor = 'rgba(255,255,255,0.1)';
+    } else {
+      filterModules.add(mod);
+      btn.style.background = 'var(--green)';
+      btn.style.color = 'var(--bg)';
+      btn.style.borderColor = 'var(--green)';
+    }
+    // If no modules selected, activate "All"
+    if (filterModules.size === 0) {
+      allBtn.style.background = 'var(--green)';
+      allBtn.style.color = 'var(--bg)';
+      allBtn.style.borderColor = 'var(--green)';
+    } else {
+      allBtn.style.background = 'var(--accent)';
+      allBtn.style.color = 'var(--text)';
+      allBtn.style.borderColor = 'rgba(255,255,255,0.1)';
+    }
+  }
+  applyFilters();
+}
+
+// Combined filter function — applies category + text + modules + CAN IDs
+function applyFilters() {
+  filterText = (document.getElementById('filterSearch') || {value: ''}).value.toLowerCase();
+  // Parse CAN IDs from comma-separated hex input
+  const canIdRaw = (document.getElementById('filterCanId') || {value: ''}).value.trim();
+  filterCanIds = canIdRaw ? canIdRaw.split(',').map(s => s.trim().toLowerCase().replace(/^0x/, '')).filter(s => s.length > 0) : [];
+  renderFilteredFeed();
+}
+
+function renderFilteredFeed() {
+  feed.innerHTML = '';
+  for (const d of allMessages) {
+    if (!messageMatchesFilters(d)) continue;
+    const div = document.createElement('div');
+    div.className = 'msg';
+    div.innerHTML = `<span class="src">${d.source}</span> → `
+      + `<span class="dst">${d.destination}</span> `
+      + `<span class="type">[${d.typeHex}] ${d.msg_name}</span> `
+      + `<span class="val">${d.payload_str}</span>`;
+    feed.appendChild(div);
+  }
+  while (feed.children.length > maxLines) feed.removeChild(feed.firstChild);
+  if (autoScroll) feed.scrollTop = feed.scrollHeight;
+}
+
+function messageMatchesFilters(d) {
+  // Category filter
+  if (activeFilter !== 'all' && !d.filter_tags.includes(activeFilter)) return false;
+  // Text search — matches against msg_name, source, destination, payload_str, typeHex
+  if (filterText) {
+    const haystack = (d.msg_name + ' ' + d.source + ' ' + d.destination + ' ' + d.payload_str + ' ' + d.typeHex).toLowerCase();
+    if (!haystack.includes(filterText)) return false;
+  }
+  // Module filter — multi-select: message matches if source OR destination is in selected modules
+  if (filterModules.size > 0) {
+    const srcHex = (d.source_hex || '').toLowerCase();
+    const dstHex = (d.destination_hex || '').toLowerCase();
+    let modMatch = false;
+    for (const mod of filterModules) {
+      if (srcHex === mod || dstHex === mod) { modMatch = true; break; }
+    }
+    if (!modMatch) return false;
+  }
+  // CAN ID filter — matches against the PF (PDU Format / message type) field only.
+  // Entering "22" matches all MOTOR_FEEDBACK messages (PF=0x22), regardless of source/destination.
+  // Comma-separated for multiple PF values. Exact 2-hex-digit match.
+  if (filterCanIds.length > 0) {
+    const pfHex = (d.msg_type || 0).toString(16).toLowerCase().padStart(2, '0');
+    if (!filterCanIds.includes(pfHex)) return false;
+  }
+  return true;
+}
+
+function clearFeed() {
+  allMessages = [];
+  feed.innerHTML = '';
+}
 
 // Statistics toggle
 function toggleStats() {
@@ -496,7 +623,15 @@ function togglePause() {
   paused = !paused;
   const btn = document.getElementById('pauseBtn');
   btn.textContent = paused ? '\u25b6 Resume' : '\u23f8 Pause';
-  btn.classList.toggle('active', paused);
+  if (paused) {
+    btn.style.background = 'var(--green)';
+    btn.style.color = 'var(--bg)';
+    btn.style.borderColor = 'var(--green)';
+  } else {
+    btn.style.background = 'var(--accent)';
+    btn.style.color = 'var(--text)';
+    btn.style.borderColor = 'rgba(255,255,255,0.1)';
+  }
 }
 
 // Batch DOM updates every 100 ms for performance
@@ -506,20 +641,11 @@ setInterval(() => {
   updateStats();
   updateLatestValues();
   if (!paused) {
-    const frag = document.createDocumentFragment();
     for (const d of msgBuffer) {
-      if (activeFilter !== 'all' && !d.filter_tags.includes(activeFilter)) continue;
-      const div = document.createElement('div');
-      div.className = 'msg';
-      div.innerHTML = `<span class="src">${d.source}</span> \u2192 `
-        + `<span class="dst">${d.destination}</span> `
-        + `<span class="type">[${d.typeHex}] ${d.msg_name}</span> `
-        + `<span class="val">${d.payload_str}</span>`;
-      frag.appendChild(div);
+      allMessages.push(d);
     }
-    feed.appendChild(frag);
-    while (feed.children.length > maxLines) feed.removeChild(feed.firstChild);
-    if (autoScroll) feed.scrollTop = feed.scrollHeight;
+    while (allMessages.length > maxLines) allMessages.shift();
+    renderFilteredFeed();
   }
   msgBuffer = [];
 }, 100);
@@ -843,9 +969,12 @@ def can_to_sse_callback(decoded_id, payload, raw_msg):
 
     event = {
         "source": decoded_id.source_name,
+        "source_hex": f"0x{decoded_id.source:02X}",
         "destination": decoded_id.destination_name,
+        "destination_hex": f"0x{decoded_id.destination:02X}",
         "msg_name": decoded_id.msg_name,
         "msg_type": decoded_id.msg_type,
+        "can_id": raw_msg.arbitration_id,
         "payload_str": payload_str,
         "payload": {k: v for k, v in payload.items() if not k.startswith("_")},
         "filter_tags": get_filter_tags(decoded_id.msg_type),
@@ -932,6 +1061,8 @@ def main():
         daemon=True,
     )
     monitor_thread.start()
+    if args.debug:
+        print(f"  Debug mode: CAN messages will be printed to terminal", flush=True)
 
     # Start demo message generator if in demo mode
     if args.demo:

--- a/tools/can_tester/web_dashboard.py
+++ b/tools/can_tester/web_dashboard.py
@@ -1,0 +1,769 @@
+#!/usr/bin/env python3
+"""
+Web dashboard for real-time CAN bus monitoring.
+
+Provides a browser-based UI at http://localhost:8080 with:
+- Live message feed via Server-Sent Events (SSE)
+- Message statistics
+- Send command panel
+- Auto-reconnecting real-time display
+
+Usage:
+    python -m tools.can_tester.web_dashboard --interface gs_usb --channel 0
+    python -m tools.can_tester.web_dashboard --interface socketcan --channel can0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import threading
+import time
+from queue import Queue, Empty, Full
+
+from flask import Flask, Response, request, jsonify, render_template_string
+
+import can
+
+from .protocol import ModuleAddress, MsgType, decode_can_id, MSG_NAMES
+from .codec import decode_payload, format_decoded
+from .sender import CanSender
+from .monitor import CanMonitor, NAMED_FILTERS
+
+app = Flask(__name__)
+
+# Global state (initialized in main)
+bus: can.BusABC = None  # type: ignore
+sender: CanSender = None  # type: ignore
+monitor: CanMonitor = None  # type: ignore
+event_queues: list[Queue] = []
+event_queues_lock = threading.Lock()
+
+# Accumulated positions for relative mode (per-command)
+_positions: dict[str, list[float]] = {}
+
+
+# ─── HTML template ───────────────────────────────────────────────────────────
+
+DASHBOARD_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>STM32LowLevel CAN Dashboard</title>
+<style>
+:root { --bg: #1a1a2e; --card: #16213e; --accent: #0f3460; --text: #e0e0e0;
+        --green: #4ecca3; --red: #e74c3c; --yellow: #f1c40f; --blue: #3498db; }
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { font-family: 'Segoe UI', system-ui, sans-serif; background: var(--bg);
+       color: var(--text); padding: 16px; }
+h1 { color: var(--green); margin-bottom: 16px; font-size: 1.5rem; }
+h2 { color: var(--blue); margin-bottom: 8px; font-size: 1.1rem; }
+.grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.card { background: var(--card); border-radius: 8px; padding: 16px; }
+#feed { height: 400px; overflow-y: auto; font-family: 'Cascadia Code', monospace;
+        font-size: 0.85rem; line-height: 1.5; }
+#feed .msg { padding: 2px 4px; border-bottom: 1px solid rgba(255,255,255,0.05); }
+#feed .msg:hover { background: rgba(255,255,255,0.05); }
+.src { color: var(--green); } .dst { color: var(--yellow); }
+.type { color: var(--blue); font-weight: bold; } .val { color: #ccc; }
+#stats table { width: 100%; border-collapse: collapse; }
+#stats td { padding: 4px 8px; border-bottom: 1px solid rgba(255,255,255,0.05); }
+#stats td:last-child { text-align: right; font-family: monospace; }
+.send-form { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+.send-form input, .send-form select { background: var(--accent); color: var(--text);
+  border: 1px solid rgba(255,255,255,0.1); padding: 6px 10px; border-radius: 4px; }
+.send-form button { background: var(--green); color: var(--bg); border: none;
+  padding: 6px 16px; border-radius: 4px; cursor: pointer; font-weight: bold; }
+.send-form button:hover { opacity: 0.9; }
+.send-form button.danger { background: var(--red); }
+.status-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%;
+  margin-right: 6px; }
+.status-dot.on { background: var(--green); } .status-dot.off { background: var(--red); }
+#connection { font-size: 0.85rem; margin-bottom: 12px; }
+.filter-bar { margin-bottom: 8px; }
+.filter-bar button { background: var(--accent); color: var(--text); border: 1px solid
+  rgba(255,255,255,0.1); padding: 4px 10px; border-radius: 4px; cursor: pointer;
+  margin-right: 4px; font-size: 0.8rem; }
+.filter-bar button.active { background: var(--green); color: var(--bg); }
+#latestValues table { width: 100%; border-collapse: collapse; }
+#latestValues td { padding: 4px 8px; border-bottom: 1px solid rgba(255,255,255,0.05); }
+#latestValues td:first-child { color: var(--blue); white-space: nowrap; }
+#latestValues td:last-child { font-family: monospace; }
+</style>
+</head>
+<body>
+<h1>STM32LowLevel CAN Dashboard</h1>
+<div id="connection"><span class="status-dot off" id="connDot"></span>
+  <span id="connText">Waiting for CAN data...</span></div>
+<div class="grid">
+  <div class="card">
+    <h2>Live Feed</h2>
+    <div class="filter-bar" id="filterBar">
+      <button class="active" data-filter="all">All</button>
+      <button data-filter="arm">Arm</button>
+      <button data-filter="traction">Traction</button>
+      <button data-filter="joint">Joint</button>
+      <button data-filter="imu">IMU</button>
+      <button data-filter="feedback">Feedback</button>
+      <button id="pauseBtn" onclick="togglePause()" style="margin-left:12px">⏸ Pause</button>
+    </div>
+    <div id="feed"></div>
+    <div style="font-size:0.75rem;color:#666;margin-top:4px" id="scrollHint"></div>
+  </div>
+  <div>
+    <div class="card" style="margin-bottom:16px">
+      <h2>Send Command</h2>
+      <div style="margin-bottom:12px">
+        <label style="font-size:0.8rem;color:var(--blue);display:block;margin-bottom:4px">Target Module</label>
+        <select id="targetModule" style="width:100%">
+          <option value="0x21">MK2_MOD1 — Head / Arm (CAN 0x21)</option>
+          <option value="0x22">MK2_MOD2 — Middle / Joint (CAN 0x22)</option>
+          <option value="0x23">MK2_MOD3 — Tail / Joint (CAN 0x23)</option>
+        </select>
+      </div>
+      <div style="margin-bottom:4px">
+        <label style="font-size:0.8rem;color:var(--blue);display:block;margin-bottom:4px">Command</label>
+        <select id="cmdType" onchange="updateForm()" style="width:100%"></select>
+      </div>
+      <p id="cmdDesc" style="font-size:0.8rem;color:#999;margin:4px 0 8px 0"></p>
+      <div class="send-form" id="sendForm">
+        <div id="inputGroup" style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+          <div id="field1" style="display:flex;flex-direction:column;gap:2px">
+            <label id="lbl1" style="font-size:0.75rem;color:var(--green)"></label>
+            <input id="val1" type="number" step="1" value="0" style="width:140px">
+          </div>
+          <div id="field2" style="display:flex;flex-direction:column;gap:2px">
+            <label id="lbl2" style="font-size:0.75rem;color:var(--green)"></label>
+            <input id="val2" type="number" step="1" value="0" style="width:140px">
+          </div>
+        </div>
+        <button onclick="sendCmd()">Send</button>
+        <button class="danger" onclick="stopAll()">STOP ALL</button>
+      </div>
+      <div id="cmdOptions" style="margin-top:8px;display:none">
+        <label style="font-size:0.8rem;color:var(--green);cursor:pointer">
+          <input type="checkbox" id="optPermanent"> Permanent (persist to flash)
+        </label>
+      </div>
+      <div id="relativeMode" style="margin-top:8px;display:none">
+        <label style="font-size:0.8rem;color:var(--green);cursor:pointer">
+          <input type="checkbox" id="optRelative"> Relative mode (delta from current)
+        </label>
+        <button id="btnResetOrigin" onclick="fetch('/reset_positions',{method:'POST'}).then(()=>{const b=document.getElementById('btnResetOrigin');b.textContent='✓ Origin Reset';setTimeout(()=>b.innerHTML='&#8634; Reset Origin',2000)})" title="Set the current position as the new zero reference for relative mode" style="margin-left:8px;font-size:0.75rem;background:var(--accent);color:var(--text);border:1px solid rgba(255,255,255,0.1);padding:2px 8px;border-radius:4px;cursor:pointer">&#8634; Reset Origin</button>
+      </div>
+      <div style="margin-top:12px;border-top:1px solid rgba(255,255,255,0.1);padding-top:8px">
+        <label style="font-size:0.8rem;color:var(--blue)">Burst Mode</label>
+        <div style="display:flex;gap:8px;align-items:center;margin-top:4px;flex-wrap:wrap">
+          <div style="display:flex;flex-direction:column;gap:2px">
+            <label style="font-size:0.75rem;color:var(--green)">Count</label>
+            <input id="burstCount" type="number" min="1" max="1000" value="1" style="width:80px">
+          </div>
+          <div style="display:flex;flex-direction:column;gap:2px">
+            <label style="font-size:0.75rem;color:var(--green)">Interval (ms)</label>
+            <input id="burstInterval" type="number" min="10" max="5000" value="100" step="10" style="width:100px">
+          </div>
+          <span id="burstStatus" style="font-size:0.75rem;color:var(--yellow)"></span>
+        </div>
+      </div>
+      <div style="margin-top:12px;border-top:1px solid rgba(255,255,255,0.1);padding-top:8px">
+        <label style="font-size:0.8rem;color:var(--blue);cursor:pointer" onclick="document.getElementById('seqPanel').style.display=document.getElementById('seqPanel').style.display==='none'?'':'none'">
+          Sequence Builder <span style="font-size:0.7rem">(click to expand)</span>
+        </label>
+        <div id="seqPanel" style="display:none;margin-top:8px">
+          <p style="font-size:0.75rem;color:#888;margin-bottom:6px">Build a sequence of commands with different parameters. Click "Add Current" to add the current command/params to the sequence.</p>
+          <div style="display:flex;gap:4px;margin-bottom:8px">
+            <button onclick="addToSequence()" style="font-size:0.75rem;background:var(--accent);color:var(--text);border:1px solid rgba(255,255,255,0.1);padding:4px 10px;border-radius:4px;cursor:pointer">+ Add Current</button>
+            <button onclick="clearSequence()" style="font-size:0.75rem;background:var(--accent);color:var(--text);border:1px solid rgba(255,255,255,0.1);padding:4px 10px;border-radius:4px;cursor:pointer">Clear</button>
+            <button onclick="runSequence()" style="font-size:0.75rem;background:var(--green);color:var(--bg);border:none;padding:4px 10px;border-radius:4px;cursor:pointer;font-weight:bold">Run Sequence</button>
+          </div>
+          <div style="display:flex;gap:8px;align-items:center;margin-bottom:6px">
+            <label style="font-size:0.75rem;color:var(--green)">Delay between (ms)</label>
+            <input id="seqDelay" type="number" min="0" max="5000" value="100" step="10" style="width:80px">
+            <label style="font-size:0.75rem;color:var(--green);cursor:pointer"><input type="checkbox" id="seqLoop"> Loop</label>
+            <label style="font-size:0.75rem;color:var(--green);cursor:pointer"><input type="checkbox" id="seqParallel"> Parallel (no delay)</label>
+          </div>
+          <div id="seqList" style="font-size:0.75rem;font-family:monospace;max-height:150px;overflow-y:auto"></div>
+          <span id="seqStatus" style="font-size:0.75rem;color:var(--yellow)"></span>
+        </div>
+      </div>
+    </div>
+    <div class="card">
+      <h2 style="cursor:pointer;user-select:none" onclick="toggleStats()">Statistics <span id="statsToggle" style="font-size:0.8rem">▾</span></h2>
+      <div id="stats"><table><tbody id="statsBody"></tbody></table></div>
+    </div>
+    <div class="card" style="margin-top:16px">
+      <h2>Latest Values</h2>
+      <div id="latestValues"><table><tbody id="latestBody"></tbody></table></div>
+    </div>
+  </div>
+</div>
+<script>
+let activeFilter = 'all';
+const feed = document.getElementById('feed');
+const maxLines = 200;
+const stats = {};
+const latestValues = {};
+let autoScroll = true;
+let lastMsgTime = 0;
+let paused = false;
+let msgBuffer = [];
+let dirty = false;
+let burstTimer = null;
+
+// Detect if user scrolled up — pause auto-scroll
+feed.addEventListener('scroll', () => {
+  const atBottom = feed.scrollHeight - feed.scrollTop - feed.clientHeight < 30;
+  autoScroll = atBottom;
+  document.getElementById('scrollHint').textContent =
+    atBottom ? '' : '⏸ Auto-scroll paused — scroll to bottom to resume';
+});
+
+// Module-specific command sets
+const CMDS_ARM = [
+  { group: 'Traction', items: [
+    { val: 'traction', label: 'Traction Motors — Set wheel speeds' },
+  ]},
+  { group: 'Robotic Arm (MOD1)', items: [
+    { val: 'arm_1a1b', label: 'Arm J1 (Differential Pitch) — Base shoulder pair' },
+    { val: 'arm_j2', label: 'Arm J2 (Elbow Pitch) — Single motor elbow' },
+    { val: 'arm_j3', label: 'Arm J3 (Roll) — Forearm rotation' },
+    { val: 'arm_j4', label: 'Arm J4 (Wrist Pitch) — Wrist up/down' },
+    { val: 'arm_j5', label: 'Arm J5 (Wrist Roll) — Wrist rotation' },
+    { val: 'beak_close', label: 'Beak Close — Gripper close' },
+    { val: 'beak_open', label: 'Beak Open — Gripper open' },
+    { val: 'reset_arm', label: 'Reset Arm — Move to home position' },
+    { val: 'reboot_arm', label: 'Reboot Arm — Restart Dynamixel motors' },
+    { val: 'set_home', label: 'Set Home — Save current position as home' },
+  ]},
+  { group: 'System', items: [
+    { val: 'reboot_traction', label: 'Reboot Traction — Restart DC motors' },
+    { val: 'stop_all', label: 'Emergency Stop — Zero all motors' },
+  ]},
+];
+
+const CMDS_JOINT = [
+  { group: 'Traction', items: [
+    { val: 'traction', label: 'Traction Motors — Set wheel speeds' },
+  ]},
+  { group: 'Inter-Module Joint', items: [
+    { val: 'joint_1a1b', label: 'Joint Pitch (Differential) — Pitch/yaw pair' },
+    { val: 'joint_roll', label: 'Joint Roll — Axial rotation' },
+  ]},
+  { group: 'System', items: [
+    { val: 'reboot_traction', label: 'Reboot Traction — Restart DC motors' },
+    { val: 'stop_all', label: 'Emergency Stop — Zero all motors' },
+  ]},
+];
+
+// Command metadata: description, field labels, numeric input count, step size
+const CMD_INFO = {
+  traction:    { desc: 'Set traction motor speeds. Positive = forward, negative = reverse. Typical range: -200 to 200 RPM.',
+                 lbl1: 'Left RPM', lbl2: 'Right RPM', inputs: 2, step: 5 },
+  arm_1a1b:   { desc: 'Set arm J1 differential shoulder joint. Theta controls yaw, phi controls pitch.',
+                 lbl1: 'Theta / Yaw (rad)', lbl2: 'Phi / Pitch (rad)', inputs: 2, step: 0.05 },
+  arm_j2:     { desc: 'Set arm elbow pitch (J2, Dynamixel XM540).',
+                 lbl1: 'Angle (rad)', lbl2: '', inputs: 1, step: 0.05 },
+  arm_j3:     { desc: 'Set arm forearm roll (J3, Dynamixel XM540).',
+                 lbl1: 'Angle (rad)', lbl2: '', inputs: 1, step: 0.05 },
+  arm_j4:     { desc: 'Set arm wrist pitch (J4, Dynamixel XL430).',
+                 lbl1: 'Angle (rad)', lbl2: '', inputs: 1, step: 0.05 },
+  arm_j5:     { desc: 'Set arm wrist roll (J5, Dynamixel XL430).',
+                 lbl1: 'Angle (rad)', lbl2: '', inputs: 1, step: 0.05 },
+  beak_close: { desc: 'Close the beak/gripper. No parameters needed — sends close command immediately.', lbl1: '', lbl2: '', inputs: 0, step: 1 },
+  beak_open:  { desc: 'Open the beak/gripper. No parameters needed — sends open command immediately.', lbl1: '', lbl2: '', inputs: 0, step: 1 },
+  reset_arm:  { desc: 'Move all arm joints to their home position. Reads current positions, then slowly returns to zero.', lbl1: '', lbl2: '', inputs: 0, step: 1 },
+  reboot_arm: { desc: 'Reboot all arm Dynamixel motors via protocol command. Use when motors are in error state.', lbl1: '', lbl2: '', inputs: 0, step: 1 },
+  set_home:   { desc: 'Set current arm position as new home. Check "Permanent" to persist across power cycles.', lbl1: '', lbl2: '', inputs: 0, step: 1, hasOptions: true },
+  reboot_traction: { desc: 'Reboot traction DC motors. Sends a reboot command to the traction controller.', lbl1: '', lbl2: '', inputs: 0, step: 1 },
+  stop_all:   { desc: 'Emergency stop — sends zero speed to all traction motors on all modules.', lbl1: '', lbl2: '', inputs: 0, step: 1 },
+  joint_1a1b: { desc: 'Set inter-module joint differential pitch/yaw. Theta controls yaw, phi controls pitch. Range: approx -1.57 to 1.57 rad.',
+                 lbl1: 'Theta / Yaw (rad)', lbl2: 'Phi / Pitch (rad)', inputs: 2, step: 0.05 },
+  joint_roll: { desc: 'Set inter-module joint axial roll. Range: approx -3.14 to 3.14 rad.',
+                 lbl1: 'Angle (rad)', lbl2: '', inputs: 1, step: 0.05 },
+};
+
+// Build command dropdown based on selected module
+function rebuildCommandDropdown() {
+  const mod = document.getElementById('targetModule').value;
+  const isArm = mod === '0x21';  // MK2_MOD1 has arm
+  const cmds = isArm ? CMDS_ARM : CMDS_JOINT;
+  const sel = document.getElementById('cmdType');
+  const prev = sel.value;
+  sel.innerHTML = '';
+  cmds.forEach(g => {
+    const og = document.createElement('optgroup');
+    og.label = g.group;
+    g.items.forEach(it => {
+      const o = document.createElement('option');
+      o.value = it.val; o.textContent = it.label;
+      og.appendChild(o);
+    });
+    sel.appendChild(og);
+  });
+  // Try to preserve previous selection
+  if ([...sel.options].some(o => o.value === prev)) sel.value = prev;
+  updateForm();
+}
+
+document.getElementById('targetModule').addEventListener('change', rebuildCommandDropdown);
+
+function updateForm() {
+  const cmd = document.getElementById('cmdType').value;
+  const info = CMD_INFO[cmd] || { desc: '', lbl1: '', lbl2: '', inputs: 0, step: 1 };
+  document.getElementById('cmdDesc').textContent = info.desc;
+  const f1 = document.getElementById('field1');
+  const f2 = document.getElementById('field2');
+  const l1 = document.getElementById('lbl1');
+  const l2 = document.getElementById('lbl2');
+  const v1 = document.getElementById('val1');
+  const v2 = document.getElementById('val2');
+  const group = document.getElementById('inputGroup');
+  l1.textContent = info.lbl1;
+  l2.textContent = info.lbl2;
+  v1.step = info.step || 1;
+  v2.step = info.step || 1;
+  f1.style.display = info.inputs >= 1 ? '' : 'none';
+  f2.style.display = info.inputs >= 2 ? '' : 'none';
+  group.style.display = info.inputs > 0 ? '' : 'none';
+  // Show permanent checkbox for set_home
+  document.getElementById('cmdOptions').style.display = info.hasOptions ? '' : 'none';
+  // Show relative mode for arm/joint angle commands
+  const isAngle = cmd.startsWith('arm_') || cmd.startsWith('joint_');
+  document.getElementById('relativeMode').style.display = (isAngle && info.inputs > 0) ? '' : 'none';
+}
+rebuildCommandDropdown();  // set initial state
+
+// Filter buttons
+document.getElementById('filterBar').addEventListener('click', e => {
+  if (e.target.dataset.filter) {
+    document.querySelectorAll('.filter-bar button').forEach(b => b.classList.remove('active'));
+    e.target.classList.add('active');
+    activeFilter = e.target.dataset.filter;
+  }
+});
+
+// Statistics toggle
+function toggleStats() {
+  const s = document.getElementById('stats');
+  const t = document.getElementById('statsToggle');
+  if (s.style.display === 'none') { s.style.display = ''; t.textContent = '▾'; }
+  else { s.style.display = 'none'; t.textContent = '▸'; }
+}
+
+// Connection status based on actual CAN message flow
+let connTimeout = null;
+function markConnected() {
+  lastMsgTime = Date.now();
+  document.getElementById('connDot').className = 'status-dot on';
+  document.getElementById('connText').textContent = 'Receiving CAN data';
+  clearTimeout(connTimeout);
+  connTimeout = setTimeout(() => {
+    document.getElementById('connDot').className = 'status-dot off';
+    document.getElementById('connText').textContent = 'No CAN data (idle > 5 s)';
+  }, 5000);
+}
+
+// SSE
+function connect() {
+  const es = new EventSource('/stream');
+  es.onopen = () => {
+    // SSE channel open — but don't show "connected" until we get CAN data
+  };
+  es.onmessage = e => {
+    const d = JSON.parse(e.data);
+    markConnected();
+    const typeHex = '0x' + d.msg_type.toString(16).toUpperCase().padStart(2, '0');
+    const key = d.msg_name + ' [' + typeHex + ']';
+    stats[key] = (stats[key] || 0) + 1;
+    latestValues[d.msg_name] = d.payload_str;
+    msgBuffer.push({...d, typeHex});
+    dirty = true;
+  };
+  es.onerror = () => {
+    document.getElementById('connDot').className = 'status-dot off';
+    document.getElementById('connText').textContent = 'SSE disconnected — reconnecting...';
+    es.close();
+    setTimeout(connect, 2000);
+  };
+}
+connect();
+
+function updateStats() {
+  const body = document.getElementById('statsBody');
+  body.innerHTML = Object.entries(stats).sort((a,b) => b[1]-a[1])
+    .map(([k,v]) => `<tr><td>${k}</td><td>${v}</td></tr>`).join('');
+}
+
+function updateLatestValues() {
+  const body = document.getElementById('latestBody');
+  body.innerHTML = Object.entries(latestValues).sort((a,b) => a[0].localeCompare(b[0]))
+    .map(([k,v]) => `<tr><td>${k}</td><td>${v || '\u2014'}</td></tr>`).join('');
+}
+
+function togglePause() {
+  paused = !paused;
+  const btn = document.getElementById('pauseBtn');
+  btn.textContent = paused ? '\u25b6 Resume' : '\u23f8 Pause';
+  btn.classList.toggle('active', paused);
+}
+
+// Batch DOM updates every 100 ms for performance
+setInterval(() => {
+  if (!dirty && msgBuffer.length === 0) return;
+  dirty = false;
+  updateStats();
+  updateLatestValues();
+  if (!paused) {
+    const frag = document.createDocumentFragment();
+    for (const d of msgBuffer) {
+      if (activeFilter !== 'all' && !d.filter_tags.includes(activeFilter)) continue;
+      const div = document.createElement('div');
+      div.className = 'msg';
+      div.innerHTML = `<span class="src">${d.source}</span> \u2192 `
+        + `<span class="dst">${d.destination}</span> `
+        + `<span class="type">[${d.typeHex}] ${d.msg_name}</span> `
+        + `<span class="val">${d.payload_str}</span>`;
+      frag.appendChild(div);
+    }
+    feed.appendChild(frag);
+    while (feed.children.length > maxLines) feed.removeChild(feed.firstChild);
+    if (autoScroll) feed.scrollTop = feed.scrollHeight;
+  }
+  msgBuffer = [];
+}, 100);
+
+function sendOne(cmd, target, v1, v2, opts) {
+  fetch('/send', {method:'POST', headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({command: cmd, target: target, val1: v1, val2: v2, ...opts})
+  }).then(r => r.json()).then(d => { if(d.error) alert(d.error); });
+}
+
+function sendCmd() {
+  const cmd = document.getElementById('cmdType').value;
+  const target = parseInt(document.getElementById('targetModule').value);
+  const v1 = parseFloat(document.getElementById('val1').value) || 0;
+  const v2 = parseFloat(document.getElementById('val2').value) || 0;
+  const count = parseInt(document.getElementById('burstCount').value) || 1;
+  const interval = parseInt(document.getElementById('burstInterval').value) || 100;
+  const opts = {};
+  if (document.getElementById('optPermanent').checked) opts.permanent = true;
+  if (document.getElementById('optRelative').checked) opts.relative = true;
+
+  if (count <= 1) { sendOne(cmd, target, v1, v2, opts); return; }
+
+  if (burstTimer) { clearInterval(burstTimer); burstTimer = null; }
+  const status = document.getElementById('burstStatus');
+  let sent = 0;
+  sendOne(cmd, target, v1, v2, opts);
+  sent++;
+  status.textContent = 'Sending ' + sent + '/' + count + '...';
+
+  burstTimer = setInterval(() => {
+    sendOne(cmd, target, v1, v2, opts);
+    sent++;
+    status.textContent = 'Sending ' + sent + '/' + count + '...';
+    if (sent >= count) {
+      clearInterval(burstTimer);
+      burstTimer = null;
+      status.textContent = 'Done \u2014 sent ' + count + ' messages';
+      setTimeout(() => status.textContent = '', 5000);
+    }
+  }, interval);
+}
+
+function stopAll() {
+  if (burstTimer) { clearInterval(burstTimer); burstTimer = null; }
+  if (seqTimer) { clearTimeout(seqTimer); seqTimer = null; seqRunning = false; }
+  document.getElementById('burstStatus').textContent = '';
+  document.getElementById('seqStatus').textContent = '';
+  fetch('/stop', {method:'POST'}).then(r => r.json());
+}
+
+// ── Sequence Builder ──
+let cmdSequence = [];
+let seqTimer = null;
+let seqRunning = false;
+
+function addToSequence() {
+  const cmd = document.getElementById('cmdType').value;
+  const target = parseInt(document.getElementById('targetModule').value);
+  const v1 = parseFloat(document.getElementById('val1').value) || 0;
+  const v2 = parseFloat(document.getElementById('val2').value) || 0;
+  const info = CMD_INFO[cmd] || {};
+  cmdSequence.push({cmd, target, v1, v2});
+  renderSequence();
+}
+
+function clearSequence() { cmdSequence = []; renderSequence(); }
+
+function removeFromSequence(i) { cmdSequence.splice(i, 1); renderSequence(); }
+
+function renderSequence() {
+  const el = document.getElementById('seqList');
+  if (cmdSequence.length === 0) { el.innerHTML = '<span style="color:#666">No commands queued</span>'; return; }
+  el.innerHTML = cmdSequence.map((s, i) => {
+    const info = CMD_INFO[s.cmd] || { lbl1: 'v1', lbl2: 'v2', inputs: 0 };
+    let params = '';
+    if (info.inputs >= 1) params += ` ${info.lbl1 || 'v1'}=${s.v1}`;
+    if (info.inputs >= 2) params += ` ${info.lbl2 || 'v2'}=${s.v2}`;
+    return `<div style="padding:2px 0;border-bottom:1px solid rgba(255,255,255,0.05);">`
+    + `<span style="color:var(--blue)">${i+1}.</span> `
+    + `<span style="color:var(--green)">${s.cmd}</span>`
+    + `<span style="color:#ccc">${params}</span> → 0x${s.target.toString(16)} `
+    + `<a href="#" onclick="removeFromSequence(${i});return false" style="color:var(--red);text-decoration:none">✕</a>`
+    + `</div>`;
+  }).join('');
+}
+renderSequence();
+
+function runSequence() {
+  if (cmdSequence.length === 0) return;
+  const delay = parseInt(document.getElementById('seqDelay').value) || 100;
+  const loop = document.getElementById('seqLoop').checked;
+  const parallel = document.getElementById('seqParallel').checked;
+  const status = document.getElementById('seqStatus');
+
+  if (parallel) {
+    cmdSequence.forEach(s => sendOne(s.cmd, s.target, s.v1, s.v2, {}));
+    status.textContent = 'Sent ' + cmdSequence.length + ' commands in parallel';
+    if (loop) { seqTimer = setTimeout(runSequence, delay); seqRunning = true; }
+    return;
+  }
+
+  seqRunning = true;
+  let idx = 0;
+  function next() {
+    if (!seqRunning) return;
+    if (idx >= cmdSequence.length) {
+      if (loop) { idx = 0; } else { status.textContent = 'Sequence complete'; seqRunning = false; return; }
+    }
+    const s = cmdSequence[idx];
+    sendOne(s.cmd, s.target, s.v1, s.v2, {});
+    status.textContent = 'Step ' + (idx+1) + '/' + cmdSequence.length;
+    idx++;
+    seqTimer = setTimeout(next, delay);
+  }
+  next();
+}
+</script>
+</body></html>"""
+
+
+# ─── Determine filter tags for a message type ───────────────────────────────
+
+def get_filter_tags(msg_type: int) -> list[str]:
+    """Return which named filters this message type belongs to."""
+    tags = []
+    for name, filter_set in NAMED_FILTERS.items():
+        if filter_set is None:
+            continue
+        if msg_type in filter_set:
+            tags.append(name)
+    return tags
+
+
+# ─── Routes ──────────────────────────────────────────────────────────────────
+
+@app.route("/")
+def index():
+    return render_template_string(DASHBOARD_HTML)
+
+
+@app.route("/stream")
+def stream():
+    """Server-Sent Events stream for live CAN messages."""
+    q: Queue = Queue(maxsize=100)
+    with event_queues_lock:
+        event_queues.append(q)
+
+    def generate():
+        try:
+            while True:
+                try:
+                    data = q.get(timeout=30)
+                    yield f"data: {json.dumps(data)}\n\n"
+                except Empty:
+                    yield ": keepalive\n\n"
+        except GeneratorExit:
+            pass
+        finally:
+            with event_queues_lock:
+                if q in event_queues:
+                    event_queues.remove(q)
+
+    return Response(generate(), mimetype="text/event-stream")
+
+
+@app.route("/send", methods=["POST"])
+def send_command():
+    """Handle send command from web UI."""
+    data = request.get_json(silent=True)
+    if not data:
+        return jsonify({"error": "Missing or invalid JSON payload"}), 400
+    cmd = data.get("command", "")
+    dest = int(data.get("target", ModuleAddress.MK2_MOD1))
+    v1 = float(data.get("val1", 0))
+    v2 = float(data.get("val2", 0))
+    permanent = data.get("permanent", False)
+    relative = data.get("relative", False)
+
+    # Relative mode: accumulate deltas into absolute positions
+    if relative and cmd in _positions:
+        _positions[cmd][0] += v1
+        _positions[cmd][1] += v2
+        v1, v2 = _positions[cmd]
+    elif relative:
+        _positions[cmd] = [v1, v2]
+    else:
+        _positions[cmd] = [v1, v2]
+
+    try:
+        if cmd == "traction":
+            sender.traction(v1, v2, destination=dest)
+        elif cmd == "arm_j2":
+            sender.arm_pitch_j2(v1)
+        elif cmd == "arm_j3":
+            sender.arm_roll_j3(v1)
+        elif cmd == "arm_j4":
+            sender.arm_pitch_j4(v1)
+        elif cmd == "arm_j5":
+            sender.arm_roll_j5(v1)
+        elif cmd == "arm_1a1b":
+            sender.arm_pitch_1a1b(v1, v2)
+        elif cmd == "beak_close":
+            sender.arm_beak(close=True)
+        elif cmd == "beak_open":
+            sender.arm_beak(close=False)
+        elif cmd == "reset_arm":
+            sender.reset_arm()
+        elif cmd == "reboot_arm":
+            sender.reboot_arm()
+        elif cmd == "set_home":
+            sender.set_home(persist=permanent)
+        elif cmd == "reboot_traction":
+            sender.reboot_traction(destination=dest)
+        elif cmd == "joint_1a1b":
+            sender.joint_pitch_1a1b(v1, v2, destination=dest)
+        elif cmd == "joint_roll":
+            sender.joint_roll(v1, destination=dest)
+        elif cmd == "stop_all":
+            sender.stop_all()
+        else:
+            return jsonify({"error": f"Unknown command: {cmd}"}), 400
+
+        return jsonify({"ok": True})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/reset_positions", methods=["POST"])
+def reset_positions():
+    """Reset accumulated relative positions to zero."""
+    _positions.clear()
+    return jsonify({"ok": True})
+
+
+@app.route("/stop", methods=["POST"])
+def stop_all():
+    """Emergency stop all motors."""
+    sender.stop_all()
+    return jsonify({"ok": True})
+
+
+# ─── CAN → SSE bridge ───────────────────────────────────────────────────────
+
+def can_to_sse_callback(decoded_id, payload, raw_msg):
+    """Push decoded CAN messages to all SSE clients."""
+    payload_str = "  ".join(
+        f"{k}={v:.4f}" if isinstance(v, float) else f"{k}={v}"
+        for k, v in payload.items()
+        if not k.startswith("_")
+    )
+
+    event = {
+        "source": decoded_id.source_name,
+        "destination": decoded_id.destination_name,
+        "msg_name": decoded_id.msg_name,
+        "msg_type": decoded_id.msg_type,
+        "payload_str": payload_str,
+        "payload": {k: v for k, v in payload.items() if not k.startswith("_")},
+        "filter_tags": get_filter_tags(decoded_id.msg_type),
+        "timestamp": raw_msg.timestamp or time.time(),
+    }
+
+    with event_queues_lock:
+        for q in event_queues:
+            try:
+                q.put_nowait(event)
+            except Full:
+                pass  # Drop if client is slow
+
+
+# ─── Main ────────────────────────────────────────────────────────────────────
+
+def main():
+    global bus, sender, monitor
+
+    parser = argparse.ArgumentParser(description="STM32LowLevel CAN Web Dashboard")
+    parser.add_argument("--interface", "-i", default="gs_usb")
+    parser.add_argument("--channel", "-c", default="0")
+    parser.add_argument("--bitrate", "-b", type=int, default=1000000,
+                        help="CAN arbitration bitrate in bps (default: 1000000 = 1 Mbit/s)")
+    parser.add_argument("--data-bitrate", "-D", type=int, default=2000000,
+                        help="CAN FD data-phase bitrate in bps (default: 2000000 = 2 Mbit/s)")
+    parser.add_argument("--port", "-p", type=int, default=8080)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument(
+        "--demo", action="store_true",
+        help="Use virtual CAN bus for GUI preview (no hardware needed)",
+    )
+    args = parser.parse_args()
+
+    iface = "virtual" if args.demo else args.interface
+    channel = "demo" if args.demo else args.channel
+
+    print(f"Connecting to CAN bus: interface={iface}, "
+          f"channel={channel}, bitrate={args.bitrate}, data_bitrate={args.data_bitrate}...")
+    if args.demo:
+        print("  (demo mode — no real CAN hardware required)")
+
+    try:
+        bus = can.Bus(
+            interface=iface,
+            channel=channel,
+            bitrate=args.bitrate,
+            data_bitrate=args.data_bitrate,
+            fd=True,
+        )
+    except Exception as e:
+        print(f"Failed to connect: {e}")
+        sys.exit(1)
+
+    sender = CanSender(bus)
+    monitor = CanMonitor(bus)
+    monitor.add_callback(can_to_sse_callback)
+
+    # Start CAN monitor in background thread
+    monitor_thread = threading.Thread(
+        target=monitor.run,
+        kwargs={"quiet": True},
+        daemon=True,
+    )
+    monitor_thread.start()
+
+    print(f"Dashboard: http://localhost:{args.port}")
+    print("Press Ctrl+C to stop.\n")
+
+    try:
+        app.run(host=args.host, port=args.port, threaded=True)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        monitor.stop()
+        bus.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Ports `tools/can_tester/` from PicoLowLevel, updated for the STM32LowLevel CAN FD protocol.

Closes #41

## Changes

### Protocol updates
- **CAN FD**: `fd=True`, `bitrate_switch=True` on all sent frames; `--data-bitrate` / `-D` arg (default 2 Mbit/s) added to CLI and web dashboard
- **Bitrate**: default 125 kbps → **1 Mbit/s** arbitration + **2 Mbit/s** data (matches FDCAN2 config)
- **MsgType**: removed `DATA_PITCH = 0x04` (not in `communication.h`); enum now has exactly **44 entries**, all verified against `Inc/communication.h`
- **Modules**: MK2_MOD1 / MOD2 / MOD3 only — MK1 variants removed from CLI choices and web dashboard dropdown

### header_parser
- Updated `_DEFAULT_INCLUDE_DIR` to point to `STM32LowLevel/Inc`
- Added `#if A == B` / `#elif A == B` regex support for `MODULE_DEFINE == MK2_MOD1` style guards
- Added `#define NAME IDENTIFIER` resolution (handles `#define CAN_ID MK2_MOD1`)
- Added `_MODULE_ADDRESSES` map and `predefined_values` injection for `parse_mod_config()`

### Bug fix
- `cli.py` `_handle_send`: `parts[2]` → `args[1]` (wrong variable used for `"permanent"` flag check)

### Validation
- `test_dry.py` runs without hardware; all tests pass:
  - CAN ID encode/decode round-trip
  - Payload codec (MOTOR_SETPOINT, ARM_PITCH, RESET_ARM)
  - Module config: CAN_ID 0x21/0x22/0x23 verified per variant
  - MsgType count == 44
  - 7 test sequences importable