### PR TITLE
feat(build): add Windows flash workflow and conditional debug logging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        module: [MK2_MOD1, MK2_MOD2, MK2_MOD3]
-    name: Build (${{ matrix.module }})
+        include:
+          - preset: MK2_MOD1
+            build-dir: build/debug/MK2_MOD1
+          - preset: MK2_MOD2
+            build-dir: build/debug/MK2_MOD2
+          - preset: MK2_MOD3
+            build-dir: build/debug/MK2_MOD3
+          - preset: MK2_MOD1-release
+            build-dir: build/release/MK2_MOD1
+          - preset: MK2_MOD2-release
+            build-dir: build/release/MK2_MOD2
+          - preset: MK2_MOD3-release
+            build-dir: build/release/MK2_MOD3
+    name: Build (${{ matrix.preset }})
     steps:
       - uses: actions/checkout@v4
 
@@ -22,10 +34,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build gcc-arm-none-eabi
 
-      - name: Configure (${{ matrix.module }})
+      - name: Configure (${{ matrix.preset }})
         working-directory: STM32LowLevel
-        run: cmake --preset Debug -DMODULE_DEFINE=${{ matrix.module }}
+        run: cmake --preset ${{ matrix.preset }}
 
-      - name: Build (${{ matrix.module }})
+      - name: Build (${{ matrix.preset }})
         working-directory: STM32LowLevel
-        run: cmake --build build/Debug
+        run: cmake --build ${{ matrix.build-dir }}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           ARM_SYSROOT=$(arm-none-eabi-gcc -print-sysroot)
           find Core/Src Lib \( -name "*.cpp" \) \
-            | xargs clang-tidy-19 -p build/MK2_MOD1 --extra-arg="--sysroot=${ARM_SYSROOT}" \
+            | xargs clang-tidy-19 -p build/debug/MK2_MOD1 --extra-arg="--sysroot=${ARM_SYSROOT}" \
             2>&1 | tee /tmp/tidy_out.txt || true
           if grep -q "readability-identifier-naming" /tmp/tidy_out.txt; then
             echo "::error::Naming convention violations found"

--- a/README.md
+++ b/README.md
@@ -26,12 +26,18 @@ Pass the module at CMake configure time: `cmake --preset Debug -DMODULE_DEFINE=M
 
 ## Getting Started
 
+Refer to [docs/getting-started.md](./docs/getting-started.md) for detailed build and flash instructions, including CMake presets and GitHub Actions CI workflow.
+
 **Prerequisites:** CMake ≥ 3.22, Ninja, `arm-none-eabi-gcc`
 
 ```bash
 cd STM32LowLevel/STM32LowLevel
-cmake --preset Debug -DMODULE_DEFINE=MK2_MOD1
-cmake --build build/MK2_MOD1 --parallel
+cmake --preset MK2_MOD1 && cmake --build build/debug/MK2_MOD1 --parallel
+```
+
+For release builds (debug output compiled out, optimized):
+```bash
+cmake --preset MK2_MOD1-release && cmake --build build/release/MK2_MOD1 --parallel
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -26,19 +26,33 @@ Pass the module at CMake configure time: `cmake --preset Debug -DMODULE_DEFINE=M
 
 ## Getting Started
 
-Refer to [docs/getting-started.md](./docs/getting-started.md) for detailed build and flash instructions, including CMake presets and GitHub Actions CI workflow.
+Refer to [docs/getting-started.md](./docs/getting-started.md) for detailed environment setup, build, and flashing instructions.
 
-**Prerequisites:** CMake ≥ 3.22, Ninja, `arm-none-eabi-gcc`
+**Prerequisites:** CMake ≥ 3.25 (required for workflows), Ninja, `arm-none-eabi-gcc`.
 
+### Building & Flashing
+
+If you only want to compile the code without triggering the flashing tool:
 ```bash
 cd STM32LowLevel/STM32LowLevel
-cmake --preset MK2_MOD1 && cmake --build build/debug/MK2_MOD1 --parallel
+cmake --preset MK2_MOD1 && cmake --build --preset MK2_MOD1
 ```
 
-For release builds (debug output compiled out, optimized):
+For release builds (optimized, debug logging stripped out):
 ```bash
-cmake --preset MK2_MOD1-release && cmake --build build/release/MK2_MOD1 --parallel
+cmake --preset MK2_MOD1-release && cmake --build --preset MK2_MOD1-release
 ```
+
+If you want to compile and flash your code directly to your target module using integrated CMake Workflows:
+```bash
+# Flash Debug build (Includes runtime logging)
+cmake --workflow --preset MK2_MOD1-flash
+
+# Flash Release build (Optimized, logs compiled out)
+cmake --workflow --preset MK2_MOD1-release-flash
+```
+
+*Change MK2_MOD1 to MK2_MOD2 (Middle) or MK2_MOD3 (Tail) depending on your target board.*
 
 ---
 

--- a/STM32LowLevel/CMakeLists.txt
+++ b/STM32LowLevel/CMakeLists.txt
@@ -200,6 +200,15 @@ target_link_options(${CMAKE_PROJECT_NAME} PRIVATE
     -Wl,-u,_printf_float
 )
 
+# Add flash target (requires dfu-util)
+add_custom_target(flash
+    COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:${CMAKE_PROJECT_NAME}> ${CMAKE_PROJECT_NAME}.bin
+    COMMAND dfu-util -d 0483:df11 -a 0 --dfuse-address 0x08000000 -D ${CMAKE_PROJECT_NAME}.bin
+    DEPENDS ${CMAKE_PROJECT_NAME}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMENT "Flashing ${CMAKE_PROJECT_NAME}.bin to STM32 via DFU"
+)
+
 # Add linked libraries
 target_link_libraries(${CMAKE_PROJECT_NAME}
     stm32cubemx

--- a/STM32LowLevel/CMakeLists.txt
+++ b/STM32LowLevel/CMakeLists.txt
@@ -200,14 +200,29 @@ target_link_options(${CMAKE_PROJECT_NAME} PRIVATE
     -Wl,-u,_printf_float
 )
 
-# Add flash target (requires dfu-util)
-add_custom_target(flash
-    COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:${CMAKE_PROJECT_NAME}> ${CMAKE_PROJECT_NAME}.bin
-    COMMAND dfu-util -d 0483:df11 -a 0 --dfuse-address 0x08000000 -D ${CMAKE_PROJECT_NAME}.bin
-    DEPENDS ${CMAKE_PROJECT_NAME}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    COMMENT "Flashing ${CMAKE_PROJECT_NAME}.bin to STM32 via DFU"
-)
+## Add flash target (requires dfu-util)
+## On Windows hosts, a batch script handles native dfu-util detection
+## and interactive WSL fallback. On other hosts, dfu-util is called directly.
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+    add_custom_target(flash
+        COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:${CMAKE_PROJECT_NAME}> ${CMAKE_PROJECT_NAME}.bin
+        # Calls the .cmd script from your project root and passes the binary path
+        COMMAND cmd.exe /c "${CMAKE_SOURCE_DIR}/cmake/flash_stm32.cmd" "${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.bin"
+        DEPENDS ${CMAKE_PROJECT_NAME}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        COMMENT "Flashing ${CMAKE_PROJECT_NAME}.bin to STM32 via DFU"
+        USES_TERMINAL
+    )
+else()
+    add_custom_target(flash
+        COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:${CMAKE_PROJECT_NAME}> ${CMAKE_PROJECT_NAME}.bin
+        COMMAND dfu-util -d 0483:df11 -a 0 --dfuse-address 0x08000000 -D ${CMAKE_PROJECT_NAME}.bin
+        DEPENDS ${CMAKE_PROJECT_NAME}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        COMMENT "Flashing ${CMAKE_PROJECT_NAME}.bin to STM32 via DFU"
+        USES_TERMINAL
+    )
+endif()
 
 # Add linked libraries
 target_link_libraries(${CMAKE_PROJECT_NAME}

--- a/STM32LowLevel/CMakeLists.txt
+++ b/STM32LowLevel/CMakeLists.txt
@@ -18,6 +18,15 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Debug")
 endif()
 
+# Set DEBUG/NDEBUG macros based on build type
+# Debug builds: -DDEBUG enables debug code compilation
+# Release builds: -DNDEBUG disables debug code (standard assert.h behavior)
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_compile_definitions(DEBUG)
+elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
+    add_compile_definitions(NDEBUG)
+endif()
+
 # Set the project name
 set(CMAKE_PROJECT_NAME STM32LowLevel)
 
@@ -179,6 +188,17 @@ target_link_libraries(usb_device_lib PUBLIC stm32cubemx)
 
 # Remove wrong libob.a library dependency when using cpp files
 list(REMOVE_ITEM CMAKE_C_IMPLICIT_LINK_LIBRARIES ob)
+
+# Enable floating point printf support via newlib
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -u _scanf_float -u _vscanf_float")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -u _scanf_float -u _vscanf_float")
+
+# Enable newlib nano with float printf support
+# -u _printf_float forces the linker to include float formatting in vsnprintf/printf
+# Without this, %f produces empty output and wastes no extra flash
+target_link_options(${CMAKE_PROJECT_NAME} PRIVATE
+    -Wl,-u,_printf_float
+)
 
 # Add linked libraries
 target_link_libraries(${CMAKE_PROJECT_NAME}

--- a/STM32LowLevel/CMakePresets.json
+++ b/STM32LowLevel/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-    "version": 3,
+    "version": 6,
     "configurePresets": [
         {
             "name": "default",
@@ -81,29 +81,45 @@
         }
     ],
     "buildPresets": [
+        { "name": "MK2_MOD1", "configurePreset": "MK2_MOD1" },
+        { "name": "MK2_MOD1-release", "configurePreset": "MK2_MOD1-release" },
+        { "name": "MK2_MOD1-flash", "configurePreset": "MK2_MOD1", "targets": ["flash"] },
+        { "name": "MK2_MOD1-release-flash", "configurePreset": "MK2_MOD1-release", "targets": ["flash"] },
+
+        { "name": "MK2_MOD2", "configurePreset": "MK2_MOD2" },
+        { "name": "MK2_MOD2-release", "configurePreset": "MK2_MOD2-release" },
+        { "name": "MK2_MOD2-flash", "configurePreset": "MK2_MOD2", "targets": ["flash"] },
+        { "name": "MK2_MOD2-release-flash", "configurePreset": "MK2_MOD2-release", "targets": ["flash"] },
+
+        { "name": "MK2_MOD3", "configurePreset": "MK2_MOD3" },
+        { "name": "MK2_MOD3-release", "configurePreset": "MK2_MOD3-release" },
+        { "name": "MK2_MOD3-flash", "configurePreset": "MK2_MOD3", "targets": ["flash"] },
+        { "name": "MK2_MOD3-release-flash", "configurePreset": "MK2_MOD3-release", "targets": ["flash"] }
+    ],
+    "workflowPresets": [
         {
-            "name": "MK2_MOD1",
-            "configurePreset": "MK2_MOD1"
+            "name": "MK2_MOD1-flash",
+            "steps": [{ "type": "configure", "name": "MK2_MOD1" }, { "type": "build", "name": "MK2_MOD1-flash" }]
         },
         {
-            "name": "MK2_MOD2",
-            "configurePreset": "MK2_MOD2"
+            "name": "MK2_MOD1-release-flash",
+            "steps": [{ "type": "configure", "name": "MK2_MOD1-release" }, { "type": "build", "name": "MK2_MOD1-release-flash" }]
         },
         {
-            "name": "MK2_MOD3",
-            "configurePreset": "MK2_MOD3"
+            "name": "MK2_MOD2-flash",
+            "steps": [{ "type": "configure", "name": "MK2_MOD2" }, { "type": "build", "name": "MK2_MOD2-flash" }]
         },
         {
-            "name": "MK2_MOD1-release",
-            "configurePreset": "MK2_MOD1-release"
+            "name": "MK2_MOD2-release-flash",
+            "steps": [{ "type": "configure", "name": "MK2_MOD2-release" }, { "type": "build", "name": "MK2_MOD2-release-flash" }]
         },
         {
-            "name": "MK2_MOD2-release",
-            "configurePreset": "MK2_MOD2-release"
+            "name": "MK2_MOD3-flash",
+            "steps": [{ "type": "configure", "name": "MK2_MOD3" }, { "type": "build", "name": "MK2_MOD3-flash" }]
         },
         {
-            "name": "MK2_MOD3-release",
-            "configurePreset": "MK2_MOD3-release"
+            "name": "MK2_MOD3-release-flash",
+            "steps": [{ "type": "configure", "name": "MK2_MOD3-release" }, { "type": "build", "name": "MK2_MOD3-release-flash" }]
         }
     ]
 }

--- a/STM32LowLevel/CMakePresets.json
+++ b/STM32LowLevel/CMakePresets.json
@@ -5,20 +5,21 @@
             "name": "default",
             "hidden": true,
             "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build/${presetName}",
-		    "toolchainFile": "${sourceDir}/cmake/gcc-arm-none-eabi.cmake",
+            "toolchainFile": "${sourceDir}/cmake/gcc-arm-none-eabi.cmake",
             "cacheVariables": {
             }
         },
         {
-            "name": "Debug",
+            "name": "debug",
+            "hidden": true,
             "inherits": "default",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug"
             }
         },
         {
-            "name": "Release",
+            "name": "release",
+            "hidden": true,
             "inherits": "default",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release"
@@ -26,38 +27,60 @@
         },
         {
             "name": "MK2_MOD1",
-            "inherits": "Debug",
             "displayName": "Debug — MK2 MOD1 (HEAD)",
+            "inherits": "debug",
+            "binaryDir": "${sourceDir}/build/debug/MK2_MOD1",
             "cacheVariables": {
                 "MODULE_DEFINE": "MK2_MOD1"
             }
         },
         {
             "name": "MK2_MOD2",
-            "inherits": "Debug",
             "displayName": "Debug — MK2 MOD2 (MIDDLE)",
+            "inherits": "debug",
+            "binaryDir": "${sourceDir}/build/debug/MK2_MOD2",
             "cacheVariables": {
                 "MODULE_DEFINE": "MK2_MOD2"
             }
         },
         {
             "name": "MK2_MOD3",
-            "inherits": "Debug",
             "displayName": "Debug — MK2 MOD3 (TAIL)",
+            "inherits": "debug",
+            "binaryDir": "${sourceDir}/build/debug/MK2_MOD3",
+            "cacheVariables": {
+                "MODULE_DEFINE": "MK2_MOD3"
+            }
+        },
+        {
+            "name": "MK2_MOD1-release",
+            "displayName": "Release — MK2 MOD1 (HEAD)",
+            "inherits": "release",
+            "binaryDir": "${sourceDir}/build/release/MK2_MOD1",
+            "cacheVariables": {
+                "MODULE_DEFINE": "MK2_MOD1"
+            }
+        },
+        {
+            "name": "MK2_MOD2-release",
+            "displayName": "Release — MK2 MOD2 (MIDDLE)",
+            "inherits": "release",
+            "binaryDir": "${sourceDir}/build/release/MK2_MOD2",
+            "cacheVariables": {
+                "MODULE_DEFINE": "MK2_MOD2"
+            }
+        },
+        {
+            "name": "MK2_MOD3-release",
+            "displayName": "Release — MK2 MOD3 (TAIL)",
+            "inherits": "release",
+            "binaryDir": "${sourceDir}/build/release/MK2_MOD3",
             "cacheVariables": {
                 "MODULE_DEFINE": "MK2_MOD3"
             }
         }
     ],
     "buildPresets": [
-        {
-            "name": "Debug",
-            "configurePreset": "Debug"
-        },
-        {
-            "name": "Release",
-            "configurePreset": "Release"
-        },
         {
             "name": "MK2_MOD1",
             "configurePreset": "MK2_MOD1"
@@ -69,6 +92,18 @@
         {
             "name": "MK2_MOD3",
             "configurePreset": "MK2_MOD3"
+        },
+        {
+            "name": "MK2_MOD1-release",
+            "configurePreset": "MK2_MOD1-release"
+        },
+        {
+            "name": "MK2_MOD2-release",
+            "configurePreset": "MK2_MOD2-release"
+        },
+        {
+            "name": "MK2_MOD3-release",
+            "configurePreset": "MK2_MOD3-release"
         }
     ]
 }

--- a/STM32LowLevel/Core/Src/main.cpp
+++ b/STM32LowLevel/Core/Src/main.cpp
@@ -418,9 +418,7 @@ extern "C" int main(void)
         {
             timeBat = now;
             if (!battery.charged())
-            {
                 LOG_WARN("[main] Low battery: %.2f V\n", battery.readVoltage());
-            }
         }
 
         // Telemetry / feedback (25 Hz)
@@ -537,7 +535,6 @@ static void dxlBusInit(USART_TypeDef* usart)
 static void dxlTractionInit(void)
 {
     static const uint8_t n = sizeof(tractionIds) / sizeof(tractionIds[0]);
-
 
     // Disable torque first for safe reconfiguration
     motLeft.setTorqueEnable(false);
@@ -794,9 +791,9 @@ static void tickBeakStateMachine(uint32_t now)
             beakState = BeakState::HOLDING;
             beakTempCheckMs = now;
             LOG_INFO("[beak] CLOSING\xe2\x86\x92HOLDING%s\n",
-                      timedOut     ? " (timeout)"
-                      : posReached ? " (pos)"
-                                   : " (load)");
+                     timedOut     ? " (timeout)"
+                     : posReached ? " (pos)"
+                                  : " (load)");
         }
     }
     else if (beakState == BeakState::OPENING)
@@ -829,10 +826,10 @@ static void tickBeakStateMachine(uint32_t now)
             {
                 armMot6.setGoalPWM(BEAK_HOLD_PWM / 2);
                 LOG_WARN("[beak] Thermal: %u deg"
-                          "C >= %u deg"
-                          "C limit, PWM halved\n",
-                          temp,
-                          (uint8_t)BEAK_TEMP_LIMIT);
+                         "C >= %u deg"
+                         "C limit, PWM halved\n",
+                         temp,
+                         (uint8_t)BEAK_TEMP_LIMIT);
             }
             if (hwErr != 0U)
             {

--- a/STM32LowLevel/Core/Src/main.cpp
+++ b/STM32LowLevel/Core/Src/main.cpp
@@ -344,8 +344,10 @@ extern "C" int main(void)
     }
 
     // Debug — must be first so all subsequent prints reach USB CDC
+#ifdef DEBUG
     debug.setLevel(Level::LogDebug);
-    debug.log(Level::LogInfo, "[main] Debug ready\n");
+    LOG_INFO("[main] Debug ready\n");
+#endif
 
     // LEDs — power-on indicator and DXL activity hook
     ledSet(Led::POWER, true);
@@ -355,30 +357,30 @@ extern "C" int main(void)
 
     // CAN — begin() releases STBY, so must come after MX_FDCAN2_Init()
     canW.begin();
-    debug.log(Level::LogInfo, "[main] CAN ready\n");
+    LOG_INFO("[main] CAN ready\n");
 
     // DXL bus init — DE pin direction and RX flush
     dxlBusInit(USART2);
-    debug.log(Level::LogInfo, "[main] DXL bus (USART2) ready\n");
+    LOG_INFO("[main] DXL bus (USART2) ready\n");
 
     // DXL traction — Dynamixel boot sequence
     dxlTractionInit();
-    debug.log(Level::LogInfo, "[main] Traction DXL ready\n");
+    LOG_INFO("[main] Traction DXL ready\n");
 
 #ifdef MODC_ARM
     dxlArmInit();
-    debug.log(Level::LogInfo, "[main] Arm DXL ready\n");
+    LOG_INFO("[main] Arm DXL ready\n");
 #endif
 
 #ifdef MODC_JOINT
     DXL_JOINT_INIT();
-    debug.log(Level::LogInfo, "[main] Joint DXL ready\n");
+    LOG_INFO("[main] Joint DXL ready\n");
 #endif
 
     // 4a. I2C — Yaw encoder (shares I2C1 with IMU)
 #ifdef MODC_YAW
     encoderYaw.setZero();
-    debug.log(Level::LogInfo, "[main] Yaw encoder ready\n");
+    LOG_INFO("[main] Yaw encoder ready\n");
 #endif
 
     // 4b. I2C — IMU
@@ -386,7 +388,7 @@ extern "C" int main(void)
     imu.begin(IMU_ADDRESS);
     if (!imu.checkID())
     {
-        debug.log(Level::LogWarn, "[main] IMU not found at 0x%02X!\n", IMU_ADDRESS);
+        LOG_WARN("[main] IMU not found at 0x%02X!\n", IMU_ADDRESS);
     }
     else
     {
@@ -394,15 +396,14 @@ extern "C" int main(void)
         imu.enableAccel();
         imu.calibrateAccel();
         imu.calibrateGyro();
-        debug.log(Level::LogInfo, "[main] IMU ready\n");
+        LOG_INFO("[main] IMU ready\n");
     }
 #endif
 
     // 5. ADC — Battery (ADC1 LL)
     battery.begin();
-    debug.log(Level::LogInfo, "[main] Battery ready, %.2f V\n", battery.readVoltage());
-
-    debug.log(Level::LogInfo, "[main] Init complete, entering main loop\n");
+    LOG_INFO("[main] Battery ready, %.2f V\n", battery.readVoltage());
+    LOG_INFO("[main] Init complete, entering main loop\n");
 
     /* USER CODE END 2 */
 
@@ -418,12 +419,7 @@ extern "C" int main(void)
             timeBat = now;
             if (!battery.charged())
             {
-                float v = battery.readVoltage();
-                int vWhole = (int)v;
-                int vFrac = (int)((v - (float)vWhole) * 100.0f);
-                if (vFrac < 0)
-                    vFrac = -vFrac;
-                debug.log(Level::LogWarn, "[main] Low battery: %d.%02d V\n", vWhole, vFrac);
+                LOG_WARN("[main] Low battery: %.2f V\n", battery.readVoltage());
             }
         }
 
@@ -456,7 +452,7 @@ extern "C" int main(void)
             speedsDxl[0] = 0.0f;
             speedsDxl[1] = 0.0f;
             dxlTraction.setGoalVelocityRpm(speedsDxl);
-            debug.log(Level::LogWarn, "[main] CAN timeout, motors stopped\n");
+            LOG_WARN("[main] CAN timeout, motors stopped\n");
         }
 
 #ifdef MODC_ARM
@@ -542,10 +538,6 @@ static void dxlTractionInit(void)
 {
     static const uint8_t n = sizeof(tractionIds) / sizeof(tractionIds[0]);
 
-    // Enable DXL debug on all handles for visibility
-    dxlTraction.setDebug(true);
-    motLeft.setDebug(true);
-    motRight.setDebug(true);
 
     // Disable torque first for safe reconfiguration
     motLeft.setTorqueEnable(false);
@@ -569,7 +561,7 @@ static void dxlTractionInit(void)
     // Enable torque
     motLeft.setTorqueEnable(true);
     motRight.setTorqueEnable(true);
-    debug.log(Level::LogInfo, "[DXL] Traction init: torque ON\n");
+    LOG_INFO("[DXL] Traction init: torque ON\n");
 }
 
 #ifdef MODC_ARM
@@ -584,7 +576,7 @@ static bool loadHomePositions(void)
 
     if (p[7] != HOME_FLASH_MAGIC)
     {
-        debug.log(Level::LogInfo, "[Flash] No saved home — using compiled defaults\n");
+        LOG_INFO("[Flash] No saved home — using compiled defaults\n");
         return false;
     }
 
@@ -596,7 +588,7 @@ static bool loadHomePositions(void)
     armPos0Mot5 = static_cast<int32_t>(p[5]);
     armPos0Mot6 = static_cast<int32_t>(p[6]);
 
-    debug.log(Level::LogInfo, "[Flash] Home positions loaded from Flash\n");
+    LOG_INFO("[Flash] Home positions loaded from Flash\n");
     return true;
 }
 
@@ -630,7 +622,7 @@ static bool saveHomePositions(void)
     if (HAL_FLASHEx_Erase(&eraseInit, &pageError) != HAL_OK)
     {
         HAL_FLASH_Lock();
-        debug.log(Level::LogWarn, "[Flash] Erase failed (page error 0x%08lX)\n", pageError);
+        LOG_WARN("[Flash] Erase failed (page error 0x%08lX)\n", pageError);
         return false;
     }
 
@@ -644,13 +636,13 @@ static bool saveHomePositions(void)
         if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, addr, dword) != HAL_OK)
         {
             HAL_FLASH_Lock();
-            debug.log(Level::LogWarn, "[Flash] Write failed at offset %lu\n", i * 8U);
+            LOG_WARN("[Flash] Write failed at offset %lu\n", i * 8U);
             return false;
         }
     }
 
     HAL_FLASH_Lock();
-    debug.log(Level::LogInfo, "[Flash] Home positions saved to Flash\n");
+    LOG_INFO("[Flash] Home positions saved to Flash\n");
     return true;
 }
 
@@ -662,15 +654,6 @@ static bool saveHomePositions(void)
  */
 static void dxlArmInit(void)
 {
-    // Verbose DXL debug logging for prototype testing
-    armDxl.setDebug(true);
-    armMot1a.setDebug(true);
-    armMot1b.setDebug(true);
-    armMot2.setDebug(true);
-    armMot3.setDebug(true);
-    armMot4.setDebug(true);
-    armMot5.setDebug(true);
-    armMot6.setDebug(true);
 
     // Disable torque for safe reconfiguration
     armMot1a.setTorqueEnable(false);
@@ -739,7 +722,7 @@ static void dxlArmInit(void)
 
     if (!ok)
     {
-        debug.log(Level::LogWarn, "[ARM_INIT] Position read failed — torque not enabled\n");
+        LOG_WARN("[ARM_INIT] Position read failed — torque not enabled\n");
         return;
     }
 
@@ -779,7 +762,7 @@ static void dxlArmInit(void)
     armMot4.setGoalPositionEpcm(armPos0Mot4);
     armMot5.setGoalPositionEpcm(armPos0Mot5);
     armMot6.setGoalPositionEpcm(armPos0Mot6);
-    debug.log(Level::LogInfo, "[ARM_INIT] Arm DXL initialised — moving to home\n");
+    LOG_INFO("[ARM_INIT] Arm DXL initialised — moving to home\n");
 }
 
 /**
@@ -810,8 +793,7 @@ static void tickBeakStateMachine(uint32_t now)
             armMot6.setGoalPWM(BEAK_HOLD_PWM);
             beakState = BeakState::HOLDING;
             beakTempCheckMs = now;
-            debug.log(Level::LogInfo,
-                      "[beak] CLOSING\xe2\x86\x92HOLDING%s\n",
+            LOG_INFO("[beak] CLOSING\xe2\x86\x92HOLDING%s\n",
                       timedOut     ? " (timeout)"
                       : posReached ? " (pos)"
                                    : " (load)");
@@ -830,7 +812,7 @@ static void tickBeakStateMachine(uint32_t now)
             armMot6.setGoalPositionEpcm(pos);
             armMot6.setGoalPWM(BEAK_FULL_PWM);
             beakState = BeakState::IDLE;
-            debug.log(Level::LogInfo, "[beak] OPENING\xe2\x86\x92IDLE%s\n", timedOut ? " (timeout)" : " (pos)");
+            LOG_INFO("[beak] OPENING\xe2\x86\x92IDLE%s\n", timedOut ? " (timeout)" : " (pos)");
         }
     }
     else if (beakState == BeakState::HOLDING)
@@ -846,8 +828,7 @@ static void tickBeakStateMachine(uint32_t now)
             if (temp >= BEAK_TEMP_LIMIT)
             {
                 armMot6.setGoalPWM(BEAK_HOLD_PWM / 2);
-                debug.log(Level::LogWarn,
-                          "[beak] Thermal: %u deg"
+                LOG_WARN("[beak] Thermal: %u deg"
                           "C >= %u deg"
                           "C limit, PWM halved\n",
                           temp,
@@ -856,7 +837,7 @@ static void tickBeakStateMachine(uint32_t now)
             if (hwErr != 0U)
             {
                 beakState = BeakState::IDLE;
-                debug.log(Level::LogWarn, "[beak] HW error 0x%02X in HOLDING \xe2\x86\x92 IDLE\n", hwErr);
+                LOG_WARN("[beak] HW error 0x%02X in HOLDING \xe2\x86\x92 IDLE\n", hwErr);
             }
         }
     }
@@ -880,11 +861,6 @@ static void DXL_JOINT_INIT(void)
     jointMot1R.setStatusReturnLevel(2U);
     jointMot2.setStatusReturnLevel(2U);
     HAL_Delay(10U);
-
-    jointDxl.setDebug(false);
-    jointMot1L.setDebug(false);
-    jointMot1R.setDebug(false);
-    jointMot2.setDebug(false);
 
     jointDxl.enableSync(jointIds, sizeof(jointIds));
 
@@ -911,7 +887,7 @@ static void DXL_JOINT_INIT(void)
 
     if (!ok)
     {
-        debug.log(Level::LogWarn, "[JOINT_INIT] Position read failed — torque not enabled\n");
+        LOG_WARN("[JOINT_INIT] Position read failed — torque not enabled\n");
         return;
     }
 
@@ -929,7 +905,7 @@ static void DXL_JOINT_INIT(void)
     jointPos0Mot1Lr[1] = 0;
     jointPos0Mot2 = 0;
 
-    debug.log(Level::LogInfo, "[JOINT_INIT] Joint DXL initialised\n");
+    LOG_INFO("[JOINT_INIT] Joint DXL initialised\n");
 }
 #endif // MODC_JOINT
 
@@ -954,6 +930,7 @@ static void sendFeedback(void)
 #ifdef MODC_YAW
     float yawAngle = encoderYaw.readAngle();
     canW.sendMessage(JOINT_YAW_FEEDBACK, &yawAngle, 4U);
+    LOG_DEBUG("[Yaw] Angle: %.2f deg\n", yawAngle);
 #endif
 
 #ifdef MODC_ARM
@@ -1037,6 +1014,7 @@ static void sendFeedback(void)
     float imuPitch = imu.getPitch();
     canW.sendMessage(JOINT_ROLL_FEEDBACK, &imuRoll, 4U);
     canW.sendMessage(JOINT_PITCH_FEEDBACK, &imuPitch, 4U);
+    LOG_DEBUG("[IMU] Roll: %.2f deg, Pitch: %.2f deg\n", imuRoll, imuPitch);
 #endif // MODC_IMU
 
 #ifdef MODC_JOINT
@@ -1082,7 +1060,7 @@ static void handleSetpoint(uint8_t msgId, const uint8_t* msgData)
 
             float goal[2] = {speedsDxl[0], speedsDxl[1]};
             dxlTraction.setGoalVelocityRpm(goal);
-            debug.log(Level::LogDebug, "[CAN] MOTOR_SETPOINT: L=%.1f R=%.1f RPM\n", speedsDxl[0], speedsDxl[1]);
+            LOG_DEBUG("[CAN] MOTOR_SETPOINT: L=%.1f R=%.1f RPM\n", speedsDxl[0], speedsDxl[1]);
             break;
         }
 
@@ -1197,7 +1175,7 @@ static void handleSetpoint(uint8_t msgId, const uint8_t* msgData)
             armOldPosMot3 = armPos0Mot3;
             armOldPosMot4 = armPos0Mot4;
             armOldPosMot5 = armPos0Mot5;
-            debug.log(Level::LogInfo, "[CAN] RESET_ARM: moving to home\n");
+            LOG_INFO("[CAN] RESET_ARM: moving to home\n");
             break;
         }
 
@@ -1215,7 +1193,7 @@ static void handleSetpoint(uint8_t msgId, const uint8_t* msgData)
             // DXL_ARM_INIT() restores the last Flash-persisted home (or compiled defaults).
             dxlArmInit();
             beakState = BeakState::IDLE;
-            debug.log(Level::LogInfo, "[CAN] REBOOT_ARM: all arm motors rebooted and reinitialised\n");
+            LOG_INFO("[CAN] REBOOT_ARM: all arm motors rebooted and reinitialised\n");
             break;
         }
 
@@ -1239,7 +1217,7 @@ static void handleSetpoint(uint8_t msgId, const uint8_t* msgData)
             if (msgData[0] == 1U)
                 (void)saveHomePositions();
             else
-                debug.log(Level::LogInfo, "[CAN] SET_HOME: session home updated\n");
+                LOG_INFO("[CAN] SET_HOME: session home updated\n");
             break;
         }
 #endif // MODC_ARM
@@ -1276,11 +1254,11 @@ static void handleSetpoint(uint8_t msgId, const uint8_t* msgData)
             motRight.reboot();
             HAL_Delay(2000U); // Wait for motors to come back online (~1.5 s typical)
             dxlTractionInit();
-            debug.log(Level::LogInfo, "[CAN] MOTOR_TRACTION_REBOOT: traction motors rebooted\n");
+            LOG_INFO("[CAN] MOTOR_TRACTION_REBOOT: traction motors rebooted\n");
             break;
 
         default:
-            debug.log(Level::LogDebug, "[CAN] Unknown msg_id: 0x%02X\n", msgId);
+            LOG_DEBUG("[CAN] Unknown msg_id: 0x%02X\n", msgId);
             break;
     }
 }

--- a/STM32LowLevel/Lib/Debug/Debug.h
+++ b/STM32LowLevel/Lib/Debug/Debug.h
@@ -37,15 +37,15 @@ enum class Level : uint8_t
 
 // Debug macros — conditional compilation based on DEBUG/NDEBUG
 #ifdef DEBUG
-    #define LOG_DEBUG(fmt, ...) debug.log(Level::LogDebug, fmt, ##__VA_ARGS__)
-    #define LOG_INFO(fmt, ...)  debug.log(Level::LogInfo,  fmt, ##__VA_ARGS__)
-    #define LOG_WARN(fmt, ...)  debug.log(Level::LogWarn,  fmt, ##__VA_ARGS__)
-    #define DEBUG_ENABLED()     (true)
+#define LOG_DEBUG(fmt, ...) debug.log(Level::LogDebug, fmt, ##__VA_ARGS__)
+#define LOG_INFO(fmt, ...) debug.log(Level::LogInfo, fmt, ##__VA_ARGS__)
+#define LOG_WARN(fmt, ...) debug.log(Level::LogWarn, fmt, ##__VA_ARGS__)
+#define DEBUG_ENABLED() (true)
 #else
-    #define LOG_DEBUG(fmt, ...) ((void)0)
-    #define LOG_INFO(fmt, ...)  ((void)0)
-    #define LOG_WARN(fmt, ...)  ((void)0)
-    #define DEBUG_ENABLED()     (false)
+#define LOG_DEBUG(fmt, ...) ((void)0)
+#define LOG_INFO(fmt, ...) ((void)0)
+#define LOG_WARN(fmt, ...) ((void)0)
+#define DEBUG_ENABLED() (false)
 #endif
 
 /**

--- a/STM32LowLevel/Lib/Debug/Debug.h
+++ b/STM32LowLevel/Lib/Debug/Debug.h
@@ -9,6 +9,11 @@
  *   Debug.setLevel(Level::LOG_INFO);
  *   Debug.log(Level::LOG_INFO, "voltage: %.2f V\n", voltage);
  *   printf("also routes through USB CDC\n");  // via _write retarget
+ *
+ * Conditional compilation:
+ *   In Debug builds (-DDEBUG), LOG_DEBUG / LOG_INFO / LOG_WARN macros
+ *   compile to debug.log() calls. In Release builds (-DNDEBUG), they
+ *   compile to ((void)0) — zero overhead, no string data in flash.
  */
 
 #ifndef DEBUG_H
@@ -30,6 +35,19 @@ enum class Level : uint8_t
     LogDebug = 3,
 };
 
+// Debug macros — conditional compilation based on DEBUG/NDEBUG
+#ifdef DEBUG
+    #define LOG_DEBUG(fmt, ...) debug.log(Level::LogDebug, fmt, ##__VA_ARGS__)
+    #define LOG_INFO(fmt, ...)  debug.log(Level::LogInfo,  fmt, ##__VA_ARGS__)
+    #define LOG_WARN(fmt, ...)  debug.log(Level::LogWarn,  fmt, ##__VA_ARGS__)
+    #define DEBUG_ENABLED()     (true)
+#else
+    #define LOG_DEBUG(fmt, ...) ((void)0)
+    #define LOG_INFO(fmt, ...)  ((void)0)
+    #define LOG_WARN(fmt, ...)  ((void)0)
+    #define DEBUG_ENABLED()     (false)
+#endif
+
 /**
  * @brief Serial debug logger backed by USB CDC.
  *
@@ -48,7 +66,7 @@ class SerialDebug
     /**
      * @brief Write a formatted message via USB CDC if lvl <= active level.
      * @param lvl Verbosity of this message.
-     * @param fmt printf-style format string.
+     * @param fmt printf-style format string (supports %f, %.2f, etc. for floats).
      * @param ... Format arguments.
      */
     void log(Level lvl, const char* fmt, ...);

--- a/STM32LowLevel/Lib/DynamixelLL/DynamixelLL.cpp
+++ b/STM32LowLevel/Lib/DynamixelLL/DynamixelLL.cpp
@@ -477,12 +477,11 @@ DxlStatusPacket DynamixelLL::receivePacket()
         LOG_WARN("DXL: header timeout\n");
 #ifdef DEBUG
         // Debug: check if USART is still enabled and if any flags are set
-        LOG_DEBUG(
-                      "DXL: USART ISR=0x%08lX UE=%u HDSEL=%u DEM=%u\n",
-                      (unsigned long)_usart->ISR,
-                      (unsigned)LL_USART_IsEnabled(_usart),
-                      (unsigned)READ_BIT(_usart->CR3, USART_CR3_HDSEL),
-                      (unsigned)READ_BIT(_usart->CR3, USART_CR3_DEM));
+        LOG_DEBUG("DXL: USART ISR=0x%08lX UE=%u HDSEL=%u DEM=%u\n",
+                  (unsigned long)_usart->ISR,
+                  (unsigned)LL_USART_IsEnabled(_usart),
+                  (unsigned)READ_BIT(_usart->CR3, USART_CR3_HDSEL),
+                  (unsigned)READ_BIT(_usart->CR3, USART_CR3_DEM));
 #endif
         return result;
     }

--- a/STM32LowLevel/Lib/DynamixelLL/DynamixelLL.cpp
+++ b/STM32LowLevel/Lib/DynamixelLL/DynamixelLL.cpp
@@ -20,17 +20,11 @@ DynamixelLL::~DynamixelLL()
     disableSync();
 }
 
-void DynamixelLL::setDebug(bool enable)
-{
-    _debug = enable;
-}
-
 void DynamixelLL::enableSync(const uint8_t* motorIDs, uint8_t numMotors)
 {
     if (numMotors < 2)
     {
-        if (_debug)
-            debug.log(Level::LogWarn, "DXL: enableSync requires >= 2 motors\n");
+        LOG_WARN("DXL: enableSync requires >= 2 motors\n");
         return;
     }
     disableSync();
@@ -152,8 +146,7 @@ uint8_t DynamixelLL::setOperatingMode(uint8_t mode)
 {
     if (!(mode == 1 || mode == 3 || mode == 4 || mode == 16))
     {
-        if (_debug)
-            debug.log(Level::LogWarn, "DXL: unsupported operating mode %u\n", mode);
+        LOG_WARN("DXL: unsupported operating mode %u\n", mode);
         return 1u;
     }
     return writeRegister(11u, mode, 1u);
@@ -211,8 +204,7 @@ uint8_t DynamixelLL::setStatusReturnLevel(uint8_t level)
 {
     if (level > 2u)
     {
-        if (_debug)
-            debug.log(Level::LogWarn, "DXL: invalid SRL %u\n", level);
+        LOG_WARN("DXL: invalid SRL %u\n", level);
         return 1u;
     }
     return writeRegister(68u, level, 1u);
@@ -222,8 +214,7 @@ uint8_t DynamixelLL::setID(uint8_t newID)
 {
     if (newID > 253u)
     {
-        if (_debug)
-            debug.log(Level::LogWarn, "DXL: invalid ID %u\n", newID);
+        LOG_WARN("DXL: invalid ID %u\n", newID);
         return 1u;
     }
     return writeRegister(7u, newID, 1u);
@@ -233,8 +224,7 @@ uint8_t DynamixelLL::setBaudRate(uint8_t baudRate)
 {
     if (baudRate > 7u)
     {
-        if (_debug)
-            debug.log(Level::LogWarn, "DXL: invalid baud %u\n", baudRate);
+        LOG_WARN("DXL: invalid baud %u\n", baudRate);
         return 1u;
     }
     return writeRegister(8u, baudRate, 1u);
@@ -362,20 +352,20 @@ uint16_t DynamixelLL::calculateCRC(const uint8_t* data, uint16_t length)
 
 bool DynamixelLL::sendPacket(const uint8_t* packet, uint16_t length)
 {
-    if (_debug)
+#ifdef DEBUG
     {
         char hexBuf[DXL_MAX_PACKET_SIZE * 3 + 8];
         int pos = snprintf(hexBuf, sizeof(hexBuf), "DXL TX(%u):", (unsigned)length);
         for (uint16_t i = 0; i < length && pos < (int)sizeof(hexBuf) - 4; ++i)
             pos += snprintf(hexBuf + pos, sizeof(hexBuf) - pos, " %02X", packet[i]);
-        debug.log(Level::LogDebug, "%s\n", hexBuf);
+        LOG_DEBUG("%s\n", hexBuf);
     }
+#endif
 
     // Verify USART is enabled
     if (!LL_USART_IsEnabled(_usart))
     {
-        if (_debug)
-            debug.log(Level::LogWarn, "DXL: USART not enabled!\n");
+        LOG_WARN("DXL: USART not enabled!\n");
         return false;
     }
 
@@ -386,7 +376,7 @@ bool DynamixelLL::sendPacket(const uint8_t* packet, uint16_t length)
     LL_USART_ClearFlag_FE(_usart);
 
     // STEP 1: Switch the SN74LVC1T45 to Transmit mode (A -> B)
-        LL_GPIO_SetOutputPin(GPIOA, LL_GPIO_PIN_1); // DXL1_DE = HIGH (TX mode)
+    LL_GPIO_SetOutputPin(GPIOA, LL_GPIO_PIN_1); // DXL1_DE = HIGH (TX mode)
 
     // Transmit all bytes (blocking)
     for (uint16_t i = 0; i < length; ++i)
@@ -396,8 +386,7 @@ bool DynamixelLL::sendPacket(const uint8_t* packet, uint16_t length)
         {
             if (--timeout == 0U)
             {
-                if (_debug)
-                    debug.log(Level::LogWarn, "DXL: TXE timeout at byte %u\n", i);
+                LOG_WARN("DXL: TXE timeout at byte %u\n", i);
                 return false;
             }
         }
@@ -410,14 +399,13 @@ bool DynamixelLL::sendPacket(const uint8_t* packet, uint16_t length)
     {
         if (--tcTimeout == 0U)
         {
-            if (_debug)
-                debug.log(Level::LogWarn, "DXL: TC timeout\n");
+            LOG_WARN("DXL: TC timeout\n");
             return false;
         }
     }
 
     // STEP 2: Switch the SN74LVC1T45 back to Receive mode (B -> A)
-        LL_GPIO_ResetOutputPin(GPIOA, LL_GPIO_PIN_1); // DXL1_DE = LOW (RX mode)
+    LL_GPIO_ResetOutputPin(GPIOA, LL_GPIO_PIN_1); // DXL1_DE = LOW (RX mode)
 
     if (activityCb)
         activityCb();
@@ -486,17 +474,16 @@ DxlStatusPacket DynamixelLL::receivePacket()
 
     if (!headerFound)
     {
-        if (_debug)
-        {
-            debug.log(Level::LogWarn, "DXL: header timeout\n");
-            // Debug: check if USART is still enabled and if any flags are set
-            debug.log(Level::LogDebug,
+        LOG_WARN("DXL: header timeout\n");
+#ifdef DEBUG
+        // Debug: check if USART is still enabled and if any flags are set
+        LOG_DEBUG(
                       "DXL: USART ISR=0x%08lX UE=%u HDSEL=%u DEM=%u\n",
                       (unsigned long)_usart->ISR,
                       (unsigned)LL_USART_IsEnabled(_usart),
                       (unsigned)READ_BIT(_usart->CR3, USART_CR3_HDSEL),
                       (unsigned)READ_BIT(_usart->CR3, USART_CR3_DEM));
-        }
+#endif
         return result;
     }
 
@@ -506,8 +493,7 @@ DxlStatusPacket DynamixelLL::receivePacket()
             buf[idx++] = LL_USART_ReceiveData8(_usart);
     if (idx < 7)
     {
-        if (_debug)
-            debug.log(Level::LogWarn, "DXL: header extension timeout\n");
+        LOG_WARN("DXL: header extension timeout\n");
         return result;
     }
 
@@ -517,8 +503,7 @@ DxlStatusPacket DynamixelLL::receivePacket()
 
     if (totalPacketLength > DXL_MAX_PACKET_SIZE)
     {
-        if (_debug)
-            debug.log(Level::LogWarn, "DXL: packet too large (%u)\n", totalPacketLength);
+        LOG_WARN("DXL: packet too large (%u)\n", totalPacketLength);
         return result;
     }
 
@@ -528,25 +513,24 @@ DxlStatusPacket DynamixelLL::receivePacket()
             buf[idx++] = LL_USART_ReceiveData8(_usart);
     if (idx < totalPacketLength)
     {
-        if (_debug)
-            debug.log(Level::LogWarn, "DXL: incomplete packet (got %u/%u)\n", idx, totalPacketLength);
+        LOG_WARN("DXL: incomplete packet (got %u/%u)\n", idx, totalPacketLength);
         return result;
     }
 
-    if (_debug)
+#ifdef DEBUG
     {
         char hexBuf[DXL_MAX_PACKET_SIZE * 3 + 8];
         int pos = snprintf(hexBuf, sizeof(hexBuf), "DXL RX(%u):", totalPacketLength);
         for (uint16_t i = 0; i < totalPacketLength && pos < (int)sizeof(hexBuf) - 4; ++i)
             pos += snprintf(hexBuf + pos, sizeof(hexBuf) - pos, " %02X", buf[i]);
-        debug.log(Level::LogDebug, "%s\n", hexBuf);
+        LOG_DEBUG("%s\n", hexBuf);
     }
+#endif
 
     // verify instruction byte (must be 0x55 for status packet)
     if (buf[7] != DXL_STATUS_INST)
     {
-        if (_debug)
-            debug.log(Level::LogDebug, "DXL: echo detected, retrying\n");
+        LOG_DEBUG("DXL: echo detected, retrying\n");
         return receivePacket(); // discard echo, try again
     }
 
@@ -562,8 +546,7 @@ DxlStatusPacket DynamixelLL::receivePacket()
 
     if (receivedCRC != computedCRC)
     {
-        if (_debug)
-            debug.log(Level::LogWarn, "DXL: CRC mismatch (got %04X, expected %04X)\n", receivedCRC, computedCRC);
+        LOG_WARN("DXL: CRC mismatch (got %04X, expected %04X)\n", receivedCRC, computedCRC);
         return result;
     }
 
@@ -606,20 +589,18 @@ uint8_t DynamixelLL::writeRegister(uint16_t address, uint32_t value, uint8_t siz
 
     if (!sendPacket(packet, pktLen))
     {
-        if (_debug)
-            debug.log(Level::LogWarn, "DXL: write send failed\n");
+        LOG_WARN("DXL: write send failed\n");
         return 1u;
     }
 
     DxlStatusPacket rsp = receivePacket();
     if (!rsp.valid)
     {
-        if (_debug)
-            debug.log(Level::LogWarn, "DXL: write invalid response\n");
+        LOG_WARN("DXL: write invalid response\n");
         return 1u; // Return error when no valid status packet received
     }
-    if (_debug && rsp.error)
-        debug.log(Level::LogWarn, "DXL: write error 0x%02X\n", rsp.error);
+    if (rsp.error)
+        LOG_WARN("DXL: write error 0x%02X\n", rsp.error);
     return rsp.error;
 }
 
@@ -724,8 +705,7 @@ DynamixelLL::bulkRead(const uint8_t* ids, uint16_t* addresses, uint8_t* dataLeng
 {
     if (!sendBulkReadPacket(ids, addresses, dataLengths, count))
     {
-        if (_debug)
-            debug.log(Level::LogWarn, "DXL: error sending Bulk Read packet\n");
+        LOG_WARN("DXL: error sending Bulk Read packet\n");
         return 1;
     }
 
@@ -735,8 +715,7 @@ DynamixelLL::bulkRead(const uint8_t* ids, uint16_t* addresses, uint8_t* dataLeng
         DxlStatusPacket response = receivePacket();
         if (!response.valid || response.error != 0)
         {
-            if (_debug)
-                debug.log(Level::LogWarn, "DXL: Bulk Read error from id %u: 0x%02X\n", ids[i], response.error);
+            LOG_WARN("DXL: Bulk Read error from id %u: 0x%02X\n", ids[i], response.error);
             retError = response.error;
         }
         values[i] = 0;

--- a/STM32LowLevel/Lib/DynamixelLL/DynamixelLL.h
+++ b/STM32LowLevel/Lib/DynamixelLL/DynamixelLL.h
@@ -368,16 +368,6 @@ class DynamixelLL
     uint8_t reboot();
 
     /**
-     * @brief Enable or disable verbose debug output via the Debug library.
-     *
-     * When enabled, raw packet bytes and status responses are logged to UART5
-     * at Level::LOG_DEBUG.
-     *
-     * @param enable True to enable debug logging, false to disable.
-     */
-    void setDebug(bool enable);
-
-    /**
      * @brief Read a register from multiple servos simultaneously (SYNC_READ).
      *
      * Broadcasts a SYNC_READ packet to all `ids` and collects one status

--- a/STM32LowLevel/Lib/DynamixelLL/DynamixelLL.h
+++ b/STM32LowLevel/Lib/DynamixelLL/DynamixelLL.h
@@ -509,8 +509,7 @@ class DynamixelLL
     uint8_t _numMotors = 1;       //< Number of motors in sync group
     uint8_t* _motorIDs = nullptr; //< Motor IDs for sync group
 
-    bool _debug = false; //< True if verbose debug logging is enabled.
-    uint8_t _error = 0;  //< Last error byte received from a status packet.
+    uint8_t _error = 0; //< Last error byte received from a status packet.
 
     static void (*activityCb)(void); //< Optional TX/RX activity hook (shared across all instances).
 

--- a/STM32LowLevel/Lib/DynamixelLL/DynamixelLL.tpp
+++ b/STM32LowLevel/Lib/DynamixelLL/DynamixelLL.tpp
@@ -389,14 +389,10 @@ uint8_t DynamixelLL::getPresentVelocityRpm(float (&rpms)[N])
     int16_t temp[_numMotors];
     uint8_t err = syncRead(128, 4, _motorIDs, temp, _numMotors);
     if (err != 0)
-    {
         LOG_WARN("DXL: sync read present velocity error 0x%02X\n", err);
-    }
     else
-    {
         for (uint8_t i = 0; i < _numMotors; i++)
             rpms[i] = static_cast<float>(temp[i]) * 0.229f;
-    }
     return err;
 }
 

--- a/STM32LowLevel/Lib/DynamixelLL/DynamixelLL.tpp
+++ b/STM32LowLevel/Lib/DynamixelLL/DynamixelLL.tpp
@@ -38,8 +38,7 @@ uint8_t DynamixelLL::readRegister(uint16_t address, T& value, uint8_t size)
     // Transmit the packet.
     if (!sendPacket(packet, 14))
     {
-        if (_debug)
-            debug.log(Level::LogWarn, "DXL: read send failed\n");
+        LOG_WARN("DXL: read send failed\n");
         return 1;
     }
 
@@ -47,12 +46,11 @@ uint8_t DynamixelLL::readRegister(uint16_t address, T& value, uint8_t size)
     DxlStatusPacket response = receivePacket();
     if (!response.valid)
     {
-        if (_debug)
-            debug.log(Level::LogWarn, "DXL: invalid status packet received\n");
+        LOG_WARN("DXL: invalid status packet received\n");
         return 1u; // Return error when no valid status packet received
     }
-    if (_debug && response.error != 0)
-        debug.log(Level::LogWarn, "DXL: read error 0x%02X\n", response.error);
+    if (response.error != 0)
+        LOG_WARN("DXL: read error 0x%02X\n", response.error);
 
     value = 0;
     for (uint8_t i = 0; i < response.dataLength; i++)
@@ -67,8 +65,7 @@ uint8_t DynamixelLL::syncRead(uint16_t address, uint8_t dataLength, const uint8_
     // Send Sync Read Instruction Packet.
     if (!sendSyncReadPacket(address, dataLength, ids, count))
     {
-        if (_debug)
-            debug.log(Level::LogWarn, "DXL: sync read send failed\n");
+        LOG_WARN("DXL: sync read send failed\n");
         return 1;
     }
 
@@ -84,14 +81,12 @@ uint8_t DynamixelLL::syncRead(uint16_t address, uint8_t dataLength, const uint8_
         received++;
         if (!response.valid)
         {
-            if (_debug)
-                debug.log(Level::LogWarn, "DXL: invalid status packet received\n");
+            LOG_WARN("DXL: invalid status packet received\n");
             continue;
         }
         if (response.error != 0)
         {
-            if (_debug)
-                debug.log(Level::LogWarn, "DXL: sync read error 0x%02X from ID %u\n", response.error, response.id);
+            LOG_WARN("DXL: sync read error 0x%02X from ID %u\n", response.error, response.id);
             retError = response.error;
             continue;
         }
@@ -119,8 +114,7 @@ uint8_t DynamixelLL::setOperatingMode(const uint8_t (&modes)[N])
     {
         if (!(modes[i] == 1 || modes[i] == 3 || modes[i] == 4 || modes[i] == 16))
         {
-            if (_debug)
-                debug.log(Level::LogWarn, "DXL: unsupported operating mode %u\n", modes[i]);
+            LOG_WARN("DXL: unsupported operating mode %u\n", modes[i]);
             return 1;
         }
         processed[i] = modes[i];
@@ -246,8 +240,7 @@ uint8_t DynamixelLL::setStatusReturnLevel(const uint8_t (&levels)[N])
     {
         if (levels[i] > 2u)
         {
-            if (_debug)
-                debug.log(Level::LogWarn, "DXL: invalid SRL %u\n", levels[i]);
+            LOG_WARN("DXL: invalid SRL %u\n", levels[i]);
             return 1;
         }
         processed[i] = levels[i];
@@ -265,8 +258,7 @@ uint8_t DynamixelLL::setID(const uint8_t (&newIDs)[N])
     {
         if (newIDs[i] > 253u)
         {
-            if (_debug)
-                debug.log(Level::LogWarn, "DXL: invalid ID %u\n", newIDs[i]);
+            LOG_WARN("DXL: invalid ID %u\n", newIDs[i]);
             return 1;
         }
         processed[i] = newIDs[i];
@@ -284,8 +276,7 @@ uint8_t DynamixelLL::setBaudRate(const uint8_t (&baudRates)[N])
     {
         if (baudRates[i] > 7u)
         {
-            if (_debug)
-                debug.log(Level::LogWarn, "DXL: invalid baud %u\n", baudRates[i]);
+            LOG_WARN("DXL: invalid baud %u\n", baudRates[i]);
             return 1;
         }
         processed[i] = baudRates[i];
@@ -399,8 +390,7 @@ uint8_t DynamixelLL::getPresentVelocityRpm(float (&rpms)[N])
     uint8_t err = syncRead(128, 4, _motorIDs, temp, _numMotors);
     if (err != 0)
     {
-        if (_debug)
-            debug.log(Level::LogWarn, "DXL: sync read present velocity error 0x%02X\n", err);
+        LOG_WARN("DXL: sync read present velocity error 0x%02X\n", err);
     }
     else
     {
@@ -416,8 +406,8 @@ uint8_t DynamixelLL::getPresentPosition(int32_t (&presentPositions)[N])
     if (checkArraySize(N) != 0)
         return 1;
     uint8_t err = syncRead(132, 4, _motorIDs, presentPositions, _numMotors);
-    if (err != 0 && _debug)
-        debug.log(Level::LogWarn, "DXL: sync read present position error 0x%02X\n", err);
+    if (err != 0)
+        LOG_WARN("DXL: sync read present position error 0x%02X\n", err);
     return err;
 }
 
@@ -427,8 +417,8 @@ uint8_t DynamixelLL::getCurrentLoad(int16_t (&currentLoad)[N])
     if (checkArraySize(N) != 0)
         return 1;
     uint8_t err = syncRead(126, 2, _motorIDs, currentLoad, _numMotors);
-    if (err != 0 && _debug)
-        debug.log(Level::LogWarn, "DXL: sync read current load error 0x%02X\n", err);
+    if (err != 0)
+        LOG_WARN("DXL: sync read current load error 0x%02X\n", err);
     return err;
 }
 
@@ -441,8 +431,7 @@ uint8_t DynamixelLL::getMovingStatus(DxlMovingStatus (&status)[N])
     uint8_t err = syncRead(123, 1, _motorIDs, temp, _numMotors);
     if (err != 0)
     {
-        if (_debug)
-            debug.log(Level::LogWarn, "DXL: sync read moving status error 0x%02X\n", err);
+        LOG_WARN("DXL: sync read moving status error 0x%02X\n", err);
     }
     else
     {

--- a/STM32LowLevel/cmake/flash_stm32.cmd
+++ b/STM32LowLevel/cmake/flash_stm32.cmd
@@ -1,0 +1,140 @@
+@echo off
+setlocal enabledelayedexpansion
+
+:: Flash STM32 via dfu-util with WSL fallback
+:: Called by CMake flash target — Ninja-safe (no interactive stdin required)
+::
+:: Parameters:
+::   %1 = binary file path (absolute, Windows-style)
+::   %2 = --wsl-fallback   (internal: re-launched interactively for Y/N prompt)
+
+if "%~1"=="" (
+    echo [flash] ERROR: No binary file provided.
+    exit /b 1
+)
+
+set BIN_FILE=%~1
+set DFU_VID_PID=0483:df11
+set DFU_ADDR=0x08000000
+
+:: ── Internal re-launch path: interactive WSL Y/N prompt ──────────────────────
+if "%~2"=="--wsl-fallback" goto :wsl_interactive
+
+:: ── Primary path (called by Ninja/CMake) ─────────────────────────────────────
+echo.
+echo [flash] Target binary : %BIN_FILE%
+echo.
+
+echo [flash] Looking for native dfu-util...
+where dfu-util >nul 2>nul
+if %ERRORLEVEL% EQU 0 (
+    echo [flash] Found dfu-util. Flashing...
+    echo.
+    dfu-util -d %DFU_VID_PID% -a 0 --dfuse-address %DFU_ADDR% -D "%BIN_FILE%"
+    exit /b %ERRORLEVEL%
+)
+
+:: dfu-util not found — print install instructions
+echo [flash] dfu-util not found on this system.
+echo.
+echo [flash] Install it with one of the following:
+echo.
+where winget >nul 2>nul
+if %ERRORLEVEL% EQU 0 (
+    echo     winget install --id=NicolasFr.dfu-util
+) else (
+    echo     winget install --id=NicolasFr.dfu-util   (install winget from the Microsoft Store first)
+)
+where choco >nul 2>nul
+if %ERRORLEVEL% EQU 0 (
+    echo     choco install dfu-util
+) else (
+    echo     choco install dfu-util                    (install Chocolatey from https://chocolatey.org/install)
+)
+echo.
+echo [flash] After installing, re-run:
+echo     cmake --workflow --preset MK2_MOD1-release-flash
+echo.
+echo [flash] --- WSL fallback ---
+echo [flash] If you have dfu-util in WSL and the device attached via usbipd,
+echo [flash] a new window will open to ask whether to proceed.
+echo.
+echo [flash] Required usbipd commands before proceeding with WSL flashing (Admin PowerShell):
+echo     usbipd list
+echo     usbipd bind   --busid ^<BUSID^>
+echo     usbipd attach --wsl --busid ^<BUSID^>
+echo.
+
+:: Re-launch this script in a new interactive console window for the Y/N prompt.
+:: This is necessary because Ninja redirects stdin, making choice.exe fail.
+:: start /wait opens a new cmd window (with a real TTY) and waits for it to exit.
+start "STM32 Flash via WSL" /wait cmd.exe /c ""%~f0" "%BIN_FILE%" --wsl-fallback"
+exit /b %ERRORLEVEL%
+
+
+:: ── WSL interactive path (runs in its own console window) ────────────────────
+:wsl_interactive
+echo.
+echo [flash] ================================================================
+echo [flash]  WSL Flash Fallback
+echo [flash]  Make sure the USB device is attached to WSL via usbipd first.
+echo [flash] ================================================================
+echo.
+
+choice /C YN /N /M "[flash] Proceed with WSL flashing? [Y/N]: "
+if %ERRORLEVEL% NEQ 1 goto :wsl_cancelled
+
+echo.
+echo [flash] Converting path for WSL...
+
+:: Convert Windows path to WSL /mnt/<drive>/... path
+set WSL_PATH=%BIN_FILE%
+set WSL_PATH=%WSL_PATH:\=/%
+set WSL_PATH=%WSL_PATH:A:=/mnt/a%
+set WSL_PATH=%WSL_PATH:B:=/mnt/b%
+set WSL_PATH=%WSL_PATH:C:=/mnt/c%
+set WSL_PATH=%WSL_PATH:D:=/mnt/d%
+set WSL_PATH=%WSL_PATH:E:=/mnt/e%
+set WSL_PATH=%WSL_PATH:F:=/mnt/f%
+set WSL_PATH=%WSL_PATH:G:=/mnt/g%
+set WSL_PATH=%WSL_PATH:H:=/mnt/h%
+set WSL_PATH=%WSL_PATH:I:=/mnt/i%
+set WSL_PATH=%WSL_PATH:J:=/mnt/j%
+set WSL_PATH=%WSL_PATH:K:=/mnt/k%
+set WSL_PATH=%WSL_PATH:L:=/mnt/l%
+set WSL_PATH=%WSL_PATH:M:=/mnt/m%
+set WSL_PATH=%WSL_PATH:N:=/mnt/n%
+set WSL_PATH=%WSL_PATH:O:=/mnt/o%
+set WSL_PATH=%WSL_PATH:P:=/mnt/p%
+set WSL_PATH=%WSL_PATH:Q:=/mnt/q%
+set WSL_PATH=%WSL_PATH:R:=/mnt/r%
+set WSL_PATH=%WSL_PATH:S:=/mnt/s%
+set WSL_PATH=%WSL_PATH:T:=/mnt/t%
+set WSL_PATH=%WSL_PATH:U:=/mnt/u%
+set WSL_PATH=%WSL_PATH:V:=/mnt/v%
+set WSL_PATH=%WSL_PATH:W:=/mnt/w%
+set WSL_PATH=%WSL_PATH:X:=/mnt/x%
+set WSL_PATH=%WSL_PATH:Y:=/mnt/y%
+set WSL_PATH=%WSL_PATH:Z:=/mnt/z%
+
+echo [flash] WSL path: %WSL_PATH%
+echo.
+wsl -- bash -lc "dfu-util -d %DFU_VID_PID% -a 0 --dfuse-address %DFU_ADDR% -D '%WSL_PATH%'"
+set EXIT_CODE=%ERRORLEVEL%
+echo.
+if %EXIT_CODE% EQU 0 (
+    echo [flash] Flash complete.
+) else (
+    echo [flash] dfu-util exited with code %EXIT_CODE%.
+    echo [flash] Is the board in DFU mode? Is dfu-util installed in WSL?
+)
+echo.
+pause
+exit /b %EXIT_CODE%
+
+:wsl_cancelled
+echo.
+echo [flash] Cancelled. Binary is at: %BIN_FILE%
+echo.
+pause
+exit /b 0

--- a/STM32LowLevel/cmake/gcc-arm-none-eabi.cmake
+++ b/STM32LowLevel/cmake/gcc-arm-none-eabi.cmake
@@ -32,10 +32,10 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -fdata-sections -ffunction-sections -f
 # However, most GCC toolchains do not support this option, which causes a compilation error; for this reason, the feature is disabled by default.
 # set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fcyclomatic-complexity")
 
-set(CMAKE_C_FLAGS_DEBUG "-O0 -g3")
-set(CMAKE_C_FLAGS_RELEASE "-Os -g0")
-set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g3")
-set(CMAKE_CXX_FLAGS_RELEASE "-Os -g0")
+set(CMAKE_C_FLAGS_DEBUG "-O0 -g3 -u _printf_float")
+set(CMAKE_C_FLAGS_RELEASE "-Os -g0 -u _printf_float")
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g3 -u _printf_float")
+set(CMAKE_CXX_FLAGS_RELEASE "-Os -g0 -u _printf_float")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -fno-rtti -fno-exceptions -fno-threadsafe-statics")
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -104,65 +104,88 @@ STM32LowLevel/          ← repo root
 
 ---
 
-## 6. Build
+## 6. Build & Flash Workflows
 
 All commands run from inside `STM32LowLevel/STM32LowLevel/`.
 
-#### One-line build
+### Option A — The Single-Command Workflow (Recommended with Hardware)
 
-The simplest way to build — specify module and optionally `release`:
-
-```bash
-cmake --preset MK2_MOD1 && cmake --build --preset MK2_MOD1
-```
-
-For a release build (debug output compiled out, size-optimized):
+If your flashing environment is configured (either native Windows `dfu-util` or WSL + `usbipd` with `dfu-util` installed on the WSL side), you can execute the entire configuration, compilation, and flashing sequence with a single command utilizing CMake Workflows (requires CMake 3.25+):
 
 ```bash
-cmake --preset MK2_MOD1-release && cmake --build --preset MK2_MOD1-release
+# Debug target workflow
+cmake --workflow --preset MK2_MOD1-flash
+
+# Release target workflow
+cmake --workflow --preset MK2_MOD1-release-flash
 ```
 
-**Note:** The first time you use a preset, you must run the configure step (`cmake --preset`). Subsequent builds only need `cmake --build --preset`:
+**Note:** The workflow presets can still be used without the hardware connected. If the flashing step fails, the workflow will stop after the build step, leaving you with a compiled binary in `build/debug/MK2_MOD1/` or `build/release/MK2_MOD1/` that you can flash manually later.
+
+### Option B — Manual One-Line Build (Compile Only)
+
+To compile the project binary without launching the flashing routine:
 
 ```bash
 # First time (configure + build)
 cmake --preset MK2_MOD1 && cmake --build --preset MK2_MOD1
-# Subsequent builds (just build)
+# Subsequent debug builds (just build)
 cmake --build --preset MK2_MOD1
+
+# Release target compilation (configure + build)
+cmake --preset MK2_MOD1-release && cmake --build --preset MK2_MOD1-release
+# Subsequent release builds (just build)
+cmake --build --preset MK2_MOD1-release
 ```
 
-#### Available presets
+### Available Presets
 
-| Preset | Build dir | Debug output | Optimization |
-|---|---|---|---|
-| `MK2_MOD1` | `build/debug/MK2_MOD1` | Enabled | `-O0 -g3` |
-| `MK2_MOD2` | `build/debug/MK2_MOD2` | Enabled | `-O0 -g3` |
-| `MK2_MOD3` | `build/debug/MK2_MOD3` | Enabled | `-O0 -g3` |
-| `MK2_MOD1-release` | `build/release/MK2_MOD1` | Compiled out | `-Os -g0` |
-| `MK2_MOD2-release` | `build/release/MK2_MOD2` | Compiled out | `-Os -g0` |
-| `MK2_MOD3-release` | `build/release/MK2_MOD3` | Compiled out | `-Os -g0` |
+The project supports the following target presets across debug, release, and automated workflow configurations:
 
-**Debug builds** (`-DDEBUG`): All `debug.log()` calls compile normally. Full packet hex dumps and error messages are available via USB CDC.
-
-**Release builds** (`-DNDEBUG`): All debug logging is completely removed by the preprocessor — zero overhead from string formatting, USB CDC transfers, or branch instructions. Only warnings and errors remain.
+| Target Module | Debug Preset (With Logs) | Release Preset (Optimized) | Workflow (Debug + Flash) | Workflow (Release + Flash) |
+| --- | --- | --- | --- | --- |
+| **Head (MOD1)** | `MK2_MOD1` | `MK2_MOD1-release` | `MK2_MOD1-flash` | `MK2_MOD1-release-flash` |
+| **Middle (MOD2)** | `MK2_MOD2` | `MK2_MOD2-release` | `MK2_MOD2-flash` | `MK2_MOD2-release-flash` |
+| **Tail (MOD3)** | `MK2_MOD3` | `MK2_MOD3-release` | `MK2_MOD3-flash` | `MK2_MOD3-release-flash` |
 
 ---
 
-## 7. Flashing
+## 7. Flashing & WSL Setup
 
-**Note:** This flashing guide is written for the Linux/Ubuntu environment.
+Flashing is handled automatically via a custom script wrapper called by the `flash` target or workflow presets. On Windows hosts, the script automatically attempts a **WSL Fallback** if native Windows binaries for `dfu-util` are missing.
 
-For WSL users, you must first attach the physical USB device to your WSL instance using `usbipd` from an Administrator PowerShell prompt before running the flashing commands:
+### WSL Passthrough Prerequisites
+
+If you are running on Windows ARM64 (other Windows architectures can also use this setup) and your target `dfu-util` utility resides only inside WSL, you must pass the physical micro-controller across the virtualization layer using `usbipd`:
+
+1. Boot the board into **DFU Bootloader Mode** using the switch.
+2. Open an **Administrator PowerShell** on Windows and attach the device:
 ```powershell
-# In Windows PowerShell (Admin)
 usbipd list                        # Find the Bus ID for "DFU in FS Mode" (typically 0483:df11)
-usbipd bind --busid <ID>           # Bind the device to WSL
-usbipd attach --wsl --busid <ID>   # Bind it to your active WSL instance
+usbipd bind --busid <ID>           # Bind the device to WSL (First time only)
+usbipd attach --wsl --busid <ID>   # Route the hardware into WSL instance
 ```
 
 *See our outline documentation [Step 3: Setting Up USBIPD in PowerShell](https://docs.teamisaac.it/doc/kernel-and-usbipd-B5cYVhJ1Gv) for detailed setup instructions.*
 
-### Flashing Procedure
+### Critical WSL Default Distro Quirk
+
+When executing the scripted fallback from Windows, the script boots into your system's **Default WSL Distribution**. If you have multiple distributions (or use Docker Desktop), this can cause a `dfu-util: command not found` error even if it works in your favorite terminal.
+
+Ensure your preferred Linux distribution (where `dfu-util` is installed) is explicitly configured as your Windows default:
+
+```powershell
+# Check current defaults (marked with an asterisk *)
+wsl -l -v
+
+# Set your primary development distro as default
+wsl --set-default <Your-Distro-Name>  # e.g., wsl --set-default Ubuntu
+
+```
+
+Once `usbipd` is attached and your default distro is correct, running `cmake --workflow --preset MK2_MOD1-flash` will open an interactive prompt window, cleanly bridging your Windows build tree to your WSL flashing environment.
+
+### Manual Flashing Procedure
 
 Put your STM32G474RET6 board into DFU bootloader mode. Then, inside `STM32LowLevel/STM32LowLevel/`, run these commands sequentially:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,43 +108,43 @@ STM32LowLevel/          ← repo root
 
 All commands run from inside `STM32LowLevel/STM32LowLevel/`.
 
-#### Step 1 — Configure
+#### One-line build
 
-Pass the module you want to build using `MODULE_DEFINE`:
-
-| Module | `MODULE_DEFINE` | CAN ID |
-|---|---|---|
-| Head (ARM) | `MK2_MOD1` | `0x21` |
-| Middle (JOINT) | `MK2_MOD2` | `0x22` |
-| Tail (TRACTION) | `MK2_MOD3` | `0x23` |
+The simplest way to build — specify module and optionally `release`:
 
 ```bash
-cmake --preset Debug -DMODULE_DEFINE=MK2_MOD1
+cmake --preset MK2_MOD1 && cmake --build --preset MK2_MOD1
 ```
 
-#### Step 2 — Build
+For a release build (debug output compiled out, size-optimized):
 
 ```bash
-cmake --build build/MK2_MOD1
+cmake --preset MK2_MOD1-release && cmake --build --preset MK2_MOD1-release
 ```
 
-The output `.elf` is at `build/MK2_MOD1/STM32LowLevel.elf`.  
-Memory usage is printed at the end:
-
-```
-Memory region         Used Size  Region Size  %age Used
-             RAM:        4752 B       128 KB      3.63%
-           FLASH:       47356 B       512 KB      9.03%
-```
-
-#### Convenience — named presets
-
-The three module configurations also have named presets in `CMakePresets.json`:
+**Note:** The first time you use a preset, you must run the configure step (`cmake --preset`). Subsequent builds only need `cmake --build --preset`:
 
 ```bash
-cmake --preset MK2_MOD1   # configures + selects module in one step
-cmake --build build/MK2_MOD1
+# First time (configure + build)
+cmake --preset MK2_MOD1 && cmake --build --preset MK2_MOD1
+# Subsequent builds (just build)
+cmake --build --preset MK2_MOD1
 ```
+
+#### Available presets
+
+| Preset | Build dir | Debug output | Optimization |
+|---|---|---|---|
+| `MK2_MOD1` | `build/debug/MK2_MOD1` | Enabled | `-O0 -g3` |
+| `MK2_MOD2` | `build/debug/MK2_MOD2` | Enabled | `-O0 -g3` |
+| `MK2_MOD3` | `build/debug/MK2_MOD3` | Enabled | `-O0 -g3` |
+| `MK2_MOD1-release` | `build/release/MK2_MOD1` | Compiled out | `-Os -g0` |
+| `MK2_MOD2-release` | `build/release/MK2_MOD2` | Compiled out | `-Os -g0` |
+| `MK2_MOD3-release` | `build/release/MK2_MOD3` | Compiled out | `-Os -g0` |
+
+**Debug builds** (`-DDEBUG`): All `debug.log()` calls compile normally. Full packet hex dumps and error messages are available via USB CDC.
+
+**Release builds** (`-DNDEBUG`): All debug logging is completely removed by the preprocessor — zero overhead from string formatting, USB CDC transfers, or branch instructions. Only warnings and errors remain.
 
 ---
 
@@ -168,10 +168,10 @@ Put your STM32G474RET6 board into DFU bootloader mode. Then, inside `STM32LowLev
 
 ```bash
 # 1. Convert your compiled ELF to a raw uncompressed binary file
-arm-none-eabi-objcopy -O binary build/MK2_MOD1/STM32LowLevel.elf build/MK2_MOD1/STM32LowLevel.bin
+arm-none-eabi-objcopy -O binary build/debug/MK2_MOD1/STM32LowLevel.elf build/debug/MK2_MOD1/STM32LowLevel.bin
 
 # 2. Flash the raw binary directly to the MCU internal flash memory
-dfu-util -d 0483:df11 -a 0 --dfuse-address 0x08000000 -D build/MK2_MOD1/STM32LowLevel.bin
+dfu-util -d 0483:df11 -a 0 --dfuse-address 0x08000000 -D build/debug/MK2_MOD1/STM32LowLevel.bin
 ```
 where:
    - `0483:df11` (Vendor ID : Product ID): hardcoded USB identifier for the factory bootloader programmed by STMicroelectronics. This is the default DFU mode that all STM32G4 series chips enter when BOOT0 is tied high.
@@ -194,7 +194,18 @@ When the board powers on or resets:
 2. The firmware waits for the host DTR signal before proceeding with motor initialization
 3. If no USB connection is detected, the firmware proceeds after a timeout
 
-## (Optional) STM32CubeMX — viewing the .ioc file
+---
+
+## Notes
+
+- Reconfigure (re-run `cmake --preset ...`) whenever you switch modules. The build directory is module-specific — forgetting to reconfigure builds the wrong module silently.
+- The USB CDC port replaces the old UART5 debug output. No UART-to-serial adapter is needed for basic debug output.
+
+---
+
+## Optional Sections
+
+### STM32CubeMX — viewing the .ioc file
 
 The project includes a `STM32LowLevel.ioc` file that describes all peripheral configurations (GPIO, USART, CAN, DMA, clocks, etc.). You don't need CubeMX to **build** or **flash** the firmware, but you do need it if you want to **view or modify** the peripheral setup and regenerate the LL/HAL init code.
 
@@ -206,9 +217,111 @@ The project includes a `STM32LowLevel.ioc` file that describes all peripheral co
 
 > **Note:** Code generation will overwrite auto-generated files such as `Core/Src/gpio.c` and `Core/Src/main.c`. Any changes made **outside** the `/* USER CODE BEGIN / END */` markers will be lost. The project is already fully configured; this step is only needed if you change peripheral assignments.
 
----
+### Local GitHub Actions Testing with act
 
-## Notes
+This section is for **contributors** who want to verify CI workflows locally before pushing.
 
-- Reconfigure (re-run `cmake --preset ...`) whenever you switch modules. The build directory is module-specific — forgetting to reconfigure builds the wrong module silently.
-- The USB CDC port replaces the old UART5 debug output. No UART-to-serial adapter is needed for basic debug output.
+You can run the CI workflows locally using [act](https://github.com/nektos/act) on WSL. This is useful to verify that builds and style checks pass before opening a PR.
+
+#### Install act on WSL (Ubuntu)
+
+```bash
+curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
+```
+
+Verify:
+```bash
+act --version
+```
+
+#### Running Workflows
+
+From the `STM32LowLevel/` directory (where `.github/` lives):
+
+**List available workflows:**
+```bash
+act --list
+```
+
+**Build workflow** (runs the 3-module matrix build):
+```bash
+act push
+```
+
+This triggers the `build.yml` workflow only (which has `on: push`). All three modules (MK2_MOD1, MK2_MOD2, MK2_MOD3) are built in both debug and release configurations.
+
+**Style workflow** (clang-format + clang-tidy):
+```bash
+act pull_request
+```
+
+This triggers the `style.yml` and `build.yml` workflows (both of which have `on: pull_request`).
+
+**Run a specific job only:**
+```bash
+act --job build
+act --job build --matrix preset:MK2_MOD1
+act --job clang-format
+```
+
+#### How It Works
+
+`act` uses Docker containers to replicate the GitHub Actions runner environment locally. The first run is slower because it pulls the runner image. Subsequent runs are faster as the image is cached.
+
+> **Tip:** If you only changed code in one module, you don't need to run the full matrix. Use the one-line CMake build commands from Section 6 instead. Use `act` when you want to verify CI will pass before pushing or opening a PR.
+
+### Style Fix Guide
+
+#### Installation
+
+If clang-format-19 is not installed:
+
+```bash
+sudo apt update
+sudo apt install -y clang-format-19
+```
+
+#### Verify Style Checks
+
+To verify that all files pass the style checks:
+
+```bash
+# Test that all files pass clang-format checks (same as GitHub workflow)
+find Core/Src Lib USB_Device -name "*.cpp" -o -name "*.h" -o -name "*.tpp" | xargs clang-format-19 --dry-run --Werror
+
+# If no output, all files pass style checks
+# If output shows errors, files need formatting
+```
+
+#### Quick Auto-Fix (Recommended)
+
+To automatically fix all style issues in the project according to the style workflow:
+
+```bash
+# Navigate to STM32LowLevel directory
+cd STM32LowLevel
+
+# Format ALL files that are checked by the style workflow
+find Core/Src Lib USB_Device -name "*.cpp" -o -name "*.h" -o -name "*.tpp" | xargs clang-format-19 -i -style=file
+```
+
+#### Manual Check for Specific Files
+
+To check if a specific file needs formatting:
+
+```bash
+# Check specific file
+clang-format-19 -style=file Core/Src/main.cpp | diff -u Core/Src/main.cpp -
+
+# If no output, file is properly formatted
+# If output shows differences, file needs formatting
+```
+
+#### GitHub Style Workflow
+
+The project uses two style checks:
+
+1. **clang-format**: Checks code formatting (runs on all .cpp, .h, .tpp files)
+2. **clang-tidy**: Checks naming conventions (runs only on .cpp files)
+
+Both checks are run on pull requests to main branch.


### PR DESCRIPTION
## Description

This PR resolves the broader Issue #46 scope by updating both build/flash workflows and debug logging behavior for STM32LowLevel.

It includes:
- a Windows-safe `flash` workflow with a reliable interactive WSL fallback,
- Simplified CMake presets with module-specific build directories,
- zero-cost release-mode debug logging macros,
- updated developer docs and CI preset handling,
- up-to-date getting-started and README guidance for both native and WSL flashing.

Closes #46 

## Testing

- `cmake --preset MK2_MOD1`
- `cmake --build --preset MK2_MOD1 --target flash`
- `cmake --preset MK2_MOD1-release`
- `cmake --build --preset MK2_MOD1-release`
- Verified the flashing helper prints a WSL fallback prompt on Windows when native `dfu-util` is missing
- Verified release-mode builds omit log strings by using `LOG_*` macros

## Not Verified
- Actual `dfu-util` flashing on other Windows architectures (x86, x64) — relies on WSL fallback which has been tested
- Apple Silicon support — native `dfu-util` behavior is untested