### PR TITLE
fix(I2C): Redesign the IMU and Encoder Libraries

### DIFF
--- a/STM32LowLevel/Core/Src/main.cpp
+++ b/STM32LowLevel/Core/Src/main.cpp
@@ -185,6 +185,9 @@ static void sendFeedback(void);
 static void handleSetpoint(uint8_t msgId, const uint8_t* msgData);
 static void dxlBusInit(USART_TypeDef* usart);
 static void dxlTractionInit(void);
+#ifdef DEBUG
+static void i2cBusScan(void);
+#endif
 #ifdef MODC_ARM
 static void dxlArmInit(void);
 static bool loadHomePositions(void);
@@ -377,6 +380,11 @@ extern "C" int main(void)
     LOG_INFO("[main] Joint DXL ready\n");
 #endif
 
+    // 4. I2C bus scan — detect all devices
+#ifdef DEBUG
+    i2cBusScan();
+#endif
+
     // 4a. I2C — Yaw encoder (shares I2C1 with IMU)
 #ifdef MODC_YAW
     encoderYaw.setZero();
@@ -514,6 +522,73 @@ extern "C" void systemClockConfig(void)
 }
 
 /* USER CODE BEGIN 4 */
+
+#ifdef DEBUG
+/**
+ * Scan I2C1 bus and log all responding devices.
+ * Uses robust transfer with bus recovery on errors.
+ */
+static void i2cBusScan(void)
+{
+    LOG_INFO("[I2C] Scanning bus...\n");
+
+    // If bus is busy, try recovery first
+    if (I2C1->ISR & I2C_ISR_BUSY)
+    {
+        LOG_INFO("[I2C] Bus busy, attempting recovery...\n");
+        LL_I2C_GenerateStopCondition(I2C1);
+        for (volatile uint32_t i = 0; i < 5000; i++);
+        if (I2C1->ISR & I2C_ISR_BUSY)
+        {
+            LOG_INFO("[I2C] Recovery failed, skipping scan\n");
+            return;
+        }
+    }
+
+    uint8_t foundCount = 0;
+    for (uint8_t addr = 8U; addr < 0x78U; addr++)
+    {
+        // Wait for bus ready
+        uint32_t busyTo = 100000U;
+        while (I2C1->ISR & I2C_ISR_BUSY)
+            if (--busyTo == 0U)
+                break;
+        if (I2C1->ISR & I2C_ISR_BUSY)
+            continue;
+
+        // Clear errors
+        I2C1->ICR = I2C_ICR_NACKCF | I2C_ICR_STOPCF;
+
+        // Send address with 0-byte write (just to check ACK)
+        LL_I2C_HandleTransfer(I2C1,
+                              static_cast<uint32_t>(addr) << 1U,
+                              LL_I2C_ADDRSLAVE_7BIT,
+                              0U,
+                              LL_I2C_MODE_AUTOEND,
+                              LL_I2C_GENERATE_START_WRITE);
+
+        uint32_t timeout = 100000U;
+        while (!(I2C1->ISR & I2C_ISR_STOPF) && !(I2C1->ISR & I2C_ISR_NACKF))
+            if (--timeout == 0U)
+                break;
+
+        bool nack = (I2C1->ISR & I2C_ISR_NACKF) != 0;
+        bool stopf = (I2C1->ISR & I2C_ISR_STOPF) != 0;
+
+        if (nack)
+            I2C1->ICR = I2C_ICR_NACKCF;
+        if (stopf)
+            I2C1->ICR = I2C_ICR_STOPCF;
+
+        if (stopf && !nack)
+        {
+            LOG_INFO("[I2C] Device found at 0x%02X\n", addr);
+            foundCount++;
+        }
+    }
+    LOG_INFO("[I2C] Scan complete, %d device(s) found\n", foundCount);
+}
+#endif
 
 /**
  * Initialize a DXL bus: set DE pin to RX mode and flush stale RX data.

--- a/STM32LowLevel/Core/Src/main.cpp
+++ b/STM32LowLevel/Core/Src/main.cpp
@@ -537,7 +537,8 @@ static void i2cBusScan(void)
     {
         LOG_INFO("[I2C] Bus busy, attempting recovery...\n");
         LL_I2C_GenerateStopCondition(I2C1);
-        for (volatile uint32_t i = 0; i < 5000; i++);
+        for (volatile uint32_t i = 0; i < 5000; i++)
+            ;
         if (I2C1->ISR & I2C_ISR_BUSY)
         {
             LOG_INFO("[I2C] Recovery failed, skipping scan\n");

--- a/STM32LowLevel/Lib/AbsoluteEncoder/AbsoluteEncoder.cpp
+++ b/STM32LowLevel/Lib/AbsoluteEncoder/AbsoluteEncoder.cpp
@@ -3,13 +3,199 @@
 #include "stm32g4xx_ll_i2c.h"
 #include "stm32g4xx_ll_rcc.h"
 #include "stm32g4xx_ll_bus.h"
+#include "stm32g4xx_ll_gpio.h"
 
-// I2C timeout in milliseconds (polling loops)
-static constexpr uint32_t I2C_TIMEOUT_MS = 10U;
+// Timeout in busy-wait loops (~10 ms at 170 MHz)
+static constexpr uint32_t I2C_TIMEOUT_LOOPS = 340000U;
 
-// Rough busy-wait loop count per millisecond at 170 MHz (conservative)
-// 170e6 / 1000 / 5 (cycles per iteration) = 34000
-static constexpr uint32_t I2C_LOOPS_PER_MS = 34000U;
+/**
+ * @brief Recover a stuck I2C bus by toggling SCL clock line.
+ * Standard I2C bus recovery: clock SCL to let stuck devices finish.
+ */
+static void i2cBusRecovery(void)
+{
+    LL_GPIO_SetPinMode(GPIOA, LL_GPIO_PIN_15, LL_GPIO_MODE_OUTPUT);
+    LL_GPIO_SetPinOutputType(GPIOA, LL_GPIO_PIN_15, LL_GPIO_OUTPUT_OPENDRAIN);
+    LL_GPIO_SetPinSpeed(GPIOA, LL_GPIO_PIN_15, LL_GPIO_SPEED_FREQ_HIGH);
+
+    for (int i = 0; i < 9; i++)
+    {
+        LL_GPIO_ResetOutputPin(GPIOA, LL_GPIO_PIN_15);
+        for (volatile uint32_t d = 0; d < 1000; d++);
+        LL_GPIO_SetOutputPin(GPIOA, LL_GPIO_PIN_15);
+        for (volatile uint32_t d = 0; d < 1000; d++);
+        if (LL_GPIO_IsInputPinSet(GPIOB, LL_GPIO_PIN_7))
+            break;
+    }
+
+    LL_GPIO_SetOutputPin(GPIOA, LL_GPIO_PIN_15);
+    for (volatile uint32_t d = 0; d < 1000; d++);
+    LL_GPIO_SetOutputPin(GPIOB, LL_GPIO_PIN_7);
+    for (volatile uint32_t d = 0; d < 1000; d++);
+
+    LL_GPIO_SetPinMode(GPIOA, LL_GPIO_PIN_15, LL_GPIO_MODE_ALTERNATE);
+    LL_GPIO_SetPinOutputType(GPIOA, LL_GPIO_PIN_15, LL_GPIO_OUTPUT_OPENDRAIN);
+    LL_GPIO_SetPinSpeed(GPIOA, LL_GPIO_PIN_15, LL_GPIO_SPEED_FREQ_HIGH);
+    LL_GPIO_SetAFPin_0_7(GPIOA, LL_GPIO_PIN_15, LL_GPIO_AF_4);
+
+    for (volatile uint32_t d = 0; d < 5000; d++);
+}
+
+static inline bool waitSet(volatile uint32_t* reg, uint32_t mask)
+{
+    uint32_t count = I2C_TIMEOUT_LOOPS;
+    while (!(*reg & mask))
+        if (--count == 0U)
+            return false;
+    return true;
+}
+
+static inline bool waitClear(volatile uint32_t* reg, uint32_t mask)
+{
+    uint32_t count = I2C_TIMEOUT_LOOPS;
+    while (*reg & mask)
+        if (--count == 0U)
+            return false;
+    return true;
+}
+
+static inline void i2cClearErrors(void)
+{
+    I2C1->ICR = I2C_ICR_NACKCF | I2C_ICR_STOPCF | I2C_ICR_BERRCF |
+                I2C_ICR_ARLOCF | I2C_ICR_OVRCF | I2C_ICR_PECCF |
+                I2C_ICR_TIMOUTCF | I2C_ICR_ALERTCF;
+}
+
+/**
+ * @brief Robust I2C write-then-read (repeated start) for encoder.
+ */
+static bool i2cReadReg(uint8_t devAddr, uint8_t reg, uint8_t* buf, uint8_t len)
+{
+    if (!waitClear(&I2C1->ISR, I2C_ISR_BUSY))
+    {
+        i2cBusRecovery();
+        if (!waitClear(&I2C1->ISR, I2C_ISR_BUSY))
+            return false;
+    }
+
+    i2cClearErrors();
+
+    // Phase 1: Write register address (SOFTEND)
+    LL_I2C_HandleTransfer(I2C1,
+                          static_cast<uint32_t>(devAddr) << 1U,
+                          LL_I2C_ADDRSLAVE_7BIT,
+                          1U,
+                          LL_I2C_MODE_SOFTEND,
+                          LL_I2C_GENERATE_START_WRITE);
+
+    if (!waitSet(&I2C1->ISR, I2C_ISR_TXIS))
+    {
+        i2cBusRecovery();
+        return false;
+    }
+
+    if (I2C1->ISR & I2C_ISR_NACKF)
+    {
+        I2C1->ICR = I2C_ICR_NACKCF;
+        LL_I2C_GenerateStopCondition(I2C1);
+        waitSet(&I2C1->ISR, I2C_ISR_STOPF);
+        I2C1->ICR = I2C_ICR_STOPCF;
+        return false;
+    }
+
+    I2C1->TXDR = reg;
+
+    if (!waitSet(&I2C1->ISR, I2C_ISR_TC))
+    {
+        i2cBusRecovery();
+        return false;
+    }
+
+    // Phase 2: Read data (AUTOEND)
+    LL_I2C_HandleTransfer(I2C1,
+                          static_cast<uint32_t>(devAddr) << 1U,
+                          LL_I2C_ADDRSLAVE_7BIT,
+                          len,
+                          LL_I2C_MODE_AUTOEND,
+                          LL_I2C_GENERATE_START_READ);
+
+    for (uint8_t i = 0U; i < len; i++)
+    {
+        if (!waitSet(&I2C1->ISR, I2C_ISR_RXNE))
+        {
+            i2cBusRecovery();
+            return false;
+        }
+        buf[i] = static_cast<uint8_t>(I2C1->RXDR);
+    }
+
+    if (!waitSet(&I2C1->ISR, I2C_ISR_STOPF))
+    {
+        i2cBusRecovery();
+        return false;
+    }
+
+    I2C1->ICR = I2C_ICR_STOPCF;
+    return true;
+}
+
+/**
+ * @brief Robust I2C write register + value for encoder.
+ */
+static bool i2cWriteReg(uint8_t devAddr, uint8_t reg, uint8_t val)
+{
+    if (!waitClear(&I2C1->ISR, I2C_ISR_BUSY))
+    {
+        i2cBusRecovery();
+        if (!waitClear(&I2C1->ISR, I2C_ISR_BUSY))
+            return false;
+    }
+
+    i2cClearErrors();
+
+    LL_I2C_HandleTransfer(I2C1,
+                          static_cast<uint32_t>(devAddr) << 1U,
+                          LL_I2C_ADDRSLAVE_7BIT,
+                          2U,
+                          LL_I2C_MODE_AUTOEND,
+                          LL_I2C_GENERATE_START_WRITE);
+
+    if (!waitSet(&I2C1->ISR, I2C_ISR_TXIS))
+    {
+        i2cBusRecovery();
+        return false;
+    }
+
+    if (I2C1->ISR & I2C_ISR_NACKF)
+    {
+        I2C1->ICR = I2C_ICR_NACKCF;
+        LL_I2C_GenerateStopCondition(I2C1);
+        waitSet(&I2C1->ISR, I2C_ISR_STOPF);
+        I2C1->ICR = I2C_ICR_STOPCF;
+        return false;
+    }
+
+    I2C1->TXDR = reg;
+
+    if (!waitSet(&I2C1->ISR, I2C_ISR_TXIS))
+    {
+        i2cBusRecovery();
+        return false;
+    }
+
+    I2C1->TXDR = val;
+
+    if (!waitSet(&I2C1->ISR, I2C_ISR_STOPF))
+    {
+        i2cBusRecovery();
+        return false;
+    }
+
+    I2C1->ICR = I2C_ICR_STOPCF;
+    return true;
+}
+
+// ======================== Public Methods ========================
 
 AbsoluteEncoder::AbsoluteEncoder(uint8_t addr)
     : _addr(addr)
@@ -17,10 +203,6 @@ AbsoluteEncoder::AbsoluteEncoder(uint8_t addr)
 
 void AbsoluteEncoder::setZero()
 {
-    // Write 0 first, then read current angle and write it as the new zero.
-    //   1. zeroRegW(0)
-    //   2. newZero = readReg16(ANGLMSB_REG)
-    //   3. zeroRegW(newZero)
     writeReg(AS5048B_ZEROMSB_REG, 0x00U);
     writeReg(AS5048B_ZEROLSB_REG, 0x00U);
 
@@ -34,21 +216,28 @@ void AbsoluteEncoder::setZero()
 
 float AbsoluteEncoder::readAngle()
 {
+    const uint8_t maxRetries = 5;
     uint16_t raw = 0;
-    if (!readReg16(AS5048B_ANGLMSB_REG, raw))
-        return ENCODER_READ_ERROR;
 
-    // Clockwise: invert the raw value
-    raw = static_cast<uint16_t>((AS5048B_RESOLUTION - 1U) - raw);
+    for (uint8_t retry = 0; retry < maxRetries; retry++)
+    {
+        if (readReg16(AS5048B_ANGLMSB_REG, raw))
+        {
+            // Clockwise: invert the raw value
+            raw = static_cast<uint16_t>((AS5048B_RESOLUTION - 1U) - raw);
 
-    // Convert to degrees in [0, 360)
-    float angle = (static_cast<float>(raw) / static_cast<float>(AS5048B_RESOLUTION)) * 360.0f;
+            // Convert to degrees in [0, 360)
+            float angle = (static_cast<float>(raw) / static_cast<float>(AS5048B_RESOLUTION)) * 360.0f;
 
-    // Remap to (-180, 180]
-    if (angle > 180.0f)
-        angle -= 360.0f;
+            // Remap to (-180, 180]
+            if (angle > 180.0f)
+                angle -= 360.0f;
 
-    return angle;
+            return angle;
+        }
+    }
+
+    return ENCODER_READ_ERROR;
 }
 
 float AbsoluteEncoder::readRaw()
@@ -61,23 +250,13 @@ float AbsoluteEncoder::readRaw()
 
 bool AbsoluteEncoder::readReg8(uint8_t reg, uint8_t& out)
 {
-    if (!i2cWriteByte(_addr, reg))
-        return false;
-    return i2cReadBytes(_addr, &out, 1U);
+    return i2cReadReg(_addr, reg, &out, 1U);
 }
 
 bool AbsoluteEncoder::readReg16(uint8_t reg, uint16_t& out)
 {
-    // Write register pointer then read two consecutive bytes.
-    // Frame: [addr W][reg] RESTART [addr R][MSB][LSB]
-    // AS5048B: angle MSB register is 0xFE, LSB is 0xFF (sequential).
-    // readArray[0] = MSB (bits[13:6]), readArray[1] = LSB (bits[5:0])
-    // Combined: (MSB << 6) | (LSB & 0x3F)  — identical to ams_as5048b
-    if (!i2cWriteByte(_addr, reg))
-        return false;
-
     uint8_t buf[2] = {};
-    if (!i2cReadBytes(_addr, buf, 2U))
+    if (!i2cReadReg(_addr, reg, buf, 2U))
         return false;
 
     out = static_cast<uint16_t>(static_cast<uint16_t>(buf[0]) << 6) | static_cast<uint16_t>(buf[1] & 0x3FU);
@@ -86,138 +265,5 @@ bool AbsoluteEncoder::readReg16(uint8_t reg, uint16_t& out)
 
 bool AbsoluteEncoder::writeReg(uint8_t reg, uint8_t val)
 {
-    return i2cWriteRegByte(_addr, reg, val);
-}
-
-static inline bool waitFlag(volatile uint32_t* reg, uint32_t mask, uint32_t polarity)
-{
-    uint32_t count = I2C_TIMEOUT_MS * I2C_LOOPS_PER_MS;
-    while (((*reg & mask) == polarity) == false)
-        if (--count == 0U)
-            return false;
-    return true;
-}
-
-static inline bool waitSet(volatile uint32_t* reg, uint32_t mask)
-{
-    uint32_t count = I2C_TIMEOUT_MS * I2C_LOOPS_PER_MS;
-    while (!(*reg & mask))
-        if (--count == 0U)
-            return false;
-    return true;
-}
-
-static inline bool waitClear(volatile uint32_t* reg, uint32_t mask)
-{
-    uint32_t count = I2C_TIMEOUT_MS * I2C_LOOPS_PER_MS;
-    while (*reg & mask)
-        if (--count == 0U)
-            return false;
-    return true;
-}
-
-bool AbsoluteEncoder::i2cWriteByte(uint8_t devAddr, uint8_t reg)
-{
-    // Wait until bus is not busy
-    if (!waitClear(&I2C1->ISR, I2C_ISR_BUSY))
-        return false;
-
-    // Configure transfer: 7-bit address, 1 byte, software end (we'll do restart)
-    LL_I2C_HandleTransfer(I2C1,
-                          static_cast<uint32_t>(devAddr) << 1U,
-                          LL_I2C_ADDRSLAVE_7BIT,
-                          1U,
-                          LL_I2C_MODE_SOFTEND,
-                          LL_I2C_GENERATE_START_WRITE);
-
-    // Wait for TXIS (transmit register empty)
-    if (!waitSet(&I2C1->ISR, I2C_ISR_TXIS))
-        return false;
-    if (I2C1->ISR & I2C_ISR_NACKF)
-    {
-        I2C1->ICR = I2C_ICR_NACKCF;
-        return false;
-    }
-
-    // Write register byte
-    I2C1->TXDR = reg;
-
-    // Wait for TC (transfer complete — SOFTEND mode)
-    if (!waitSet(&I2C1->ISR, I2C_ISR_TC))
-        return false;
-
-    return true;
-}
-
-bool AbsoluteEncoder::i2cReadBytes(uint8_t devAddr, uint8_t* buf, uint8_t len)
-{
-    // Issue repeated start read transfer (AUTOEND so STOP is generated automatically)
-    LL_I2C_HandleTransfer(I2C1,
-                          static_cast<uint32_t>(devAddr) << 1U,
-                          LL_I2C_ADDRSLAVE_7BIT,
-                          len,
-                          LL_I2C_MODE_AUTOEND,
-                          LL_I2C_GENERATE_START_READ);
-
-    for (uint8_t i = 0U; i < len; i++)
-    {
-        // Wait for RXNE (receive data register not empty)
-        if (!waitSet(&I2C1->ISR, I2C_ISR_RXNE))
-            return false;
-        if (I2C1->ISR & I2C_ISR_NACKF)
-        {
-            I2C1->ICR = I2C_ICR_NACKCF;
-            return false;
-        }
-        buf[i] = static_cast<uint8_t>(I2C1->RXDR);
-    }
-
-    // Wait for STOPF (AUTOEND generates STOP automatically)
-    if (!waitSet(&I2C1->ISR, I2C_ISR_STOPF))
-        return false;
-    I2C1->ICR = I2C_ICR_STOPCF; // Clear STOPF flag
-
-    return true;
-}
-
-bool AbsoluteEncoder::i2cWriteRegByte(uint8_t devAddr, uint8_t reg, uint8_t val)
-{
-    // Wait until bus is not busy
-    if (!waitClear(&I2C1->ISR, I2C_ISR_BUSY))
-        return false;
-
-    // 2 bytes: register address + value, AUTOEND → auto STOP
-    LL_I2C_HandleTransfer(I2C1,
-                          static_cast<uint32_t>(devAddr) << 1U,
-                          LL_I2C_ADDRSLAVE_7BIT,
-                          2U,
-                          LL_I2C_MODE_AUTOEND,
-                          LL_I2C_GENERATE_START_WRITE);
-
-    // Send register address
-    if (!waitSet(&I2C1->ISR, I2C_ISR_TXIS))
-        return false;
-    if (I2C1->ISR & I2C_ISR_NACKF)
-    {
-        I2C1->ICR = I2C_ICR_NACKCF;
-        return false;
-    }
-    I2C1->TXDR = reg;
-
-    // Send value
-    if (!waitSet(&I2C1->ISR, I2C_ISR_TXIS))
-        return false;
-    if (I2C1->ISR & I2C_ISR_NACKF)
-    {
-        I2C1->ICR = I2C_ICR_NACKCF;
-        return false;
-    }
-    I2C1->TXDR = val;
-
-    // Wait for STOPF
-    if (!waitSet(&I2C1->ISR, I2C_ISR_STOPF))
-        return false;
-    I2C1->ICR = I2C_ICR_STOPCF;
-
-    return true;
+    return i2cWriteReg(_addr, reg, val);
 }

--- a/STM32LowLevel/Lib/AbsoluteEncoder/AbsoluteEncoder.cpp
+++ b/STM32LowLevel/Lib/AbsoluteEncoder/AbsoluteEncoder.cpp
@@ -21,24 +21,29 @@ static void i2cBusRecovery(void)
     for (int i = 0; i < 9; i++)
     {
         LL_GPIO_ResetOutputPin(GPIOA, LL_GPIO_PIN_15);
-        for (volatile uint32_t d = 0; d < 1000; d++);
+        for (volatile uint32_t d = 0; d < 1000; d++)
+            ;
         LL_GPIO_SetOutputPin(GPIOA, LL_GPIO_PIN_15);
-        for (volatile uint32_t d = 0; d < 1000; d++);
+        for (volatile uint32_t d = 0; d < 1000; d++)
+            ;
         if (LL_GPIO_IsInputPinSet(GPIOB, LL_GPIO_PIN_7))
             break;
     }
 
     LL_GPIO_SetOutputPin(GPIOA, LL_GPIO_PIN_15);
-    for (volatile uint32_t d = 0; d < 1000; d++);
+    for (volatile uint32_t d = 0; d < 1000; d++)
+        ;
     LL_GPIO_SetOutputPin(GPIOB, LL_GPIO_PIN_7);
-    for (volatile uint32_t d = 0; d < 1000; d++);
+    for (volatile uint32_t d = 0; d < 1000; d++)
+        ;
 
     LL_GPIO_SetPinMode(GPIOA, LL_GPIO_PIN_15, LL_GPIO_MODE_ALTERNATE);
     LL_GPIO_SetPinOutputType(GPIOA, LL_GPIO_PIN_15, LL_GPIO_OUTPUT_OPENDRAIN);
     LL_GPIO_SetPinSpeed(GPIOA, LL_GPIO_PIN_15, LL_GPIO_SPEED_FREQ_HIGH);
     LL_GPIO_SetAFPin_0_7(GPIOA, LL_GPIO_PIN_15, LL_GPIO_AF_4);
 
-    for (volatile uint32_t d = 0; d < 5000; d++);
+    for (volatile uint32_t d = 0; d < 5000; d++)
+        ;
 }
 
 static inline bool waitSet(volatile uint32_t* reg, uint32_t mask)
@@ -61,8 +66,7 @@ static inline bool waitClear(volatile uint32_t* reg, uint32_t mask)
 
 static inline void i2cClearErrors(void)
 {
-    I2C1->ICR = I2C_ICR_NACKCF | I2C_ICR_STOPCF | I2C_ICR_BERRCF |
-                I2C_ICR_ARLOCF | I2C_ICR_OVRCF | I2C_ICR_PECCF |
+    I2C1->ICR = I2C_ICR_NACKCF | I2C_ICR_STOPCF | I2C_ICR_BERRCF | I2C_ICR_ARLOCF | I2C_ICR_OVRCF | I2C_ICR_PECCF |
                 I2C_ICR_TIMOUTCF | I2C_ICR_ALERTCF;
 }
 

--- a/STM32LowLevel/Lib/IMU/IMU.cpp
+++ b/STM32LowLevel/Lib/IMU/IMU.cpp
@@ -27,9 +27,11 @@ static void i2cBusRecovery(void)
     for (int i = 0; i < 9; i++)
     {
         LL_GPIO_ResetOutputPin(GPIOA, LL_GPIO_PIN_15);
-        for (volatile uint32_t d = 0; d < 1000; d++);
+        for (volatile uint32_t d = 0; d < 1000; d++)
+            ;
         LL_GPIO_SetOutputPin(GPIOA, LL_GPIO_PIN_15);
-        for (volatile uint32_t d = 0; d < 1000; d++);
+        for (volatile uint32_t d = 0; d < 1000; d++)
+            ;
 
         // Check if SDA (PB7) has been released
         if (LL_GPIO_IsInputPinSet(GPIOB, LL_GPIO_PIN_7))
@@ -38,9 +40,11 @@ static void i2cBusRecovery(void)
 
     // Generate a STOP condition: SCL high, then SDA high
     LL_GPIO_SetOutputPin(GPIOA, LL_GPIO_PIN_15);
-    for (volatile uint32_t d = 0; d < 1000; d++);
+    for (volatile uint32_t d = 0; d < 1000; d++)
+        ;
     LL_GPIO_SetOutputPin(GPIOB, LL_GPIO_PIN_7);
-    for (volatile uint32_t d = 0; d < 1000; d++);
+    for (volatile uint32_t d = 0; d < 1000; d++)
+        ;
 
     // Reconfigure PA15 back to I2C alternate function
     LL_GPIO_SetPinMode(GPIOA, LL_GPIO_PIN_15, LL_GPIO_MODE_ALTERNATE);
@@ -49,7 +53,8 @@ static void i2cBusRecovery(void)
     LL_GPIO_SetAFPin_0_7(GPIOA, LL_GPIO_PIN_15, LL_GPIO_AF_4);
 
     // Small delay for bus to settle
-    for (volatile uint32_t d = 0; d < 5000; d++);
+    for (volatile uint32_t d = 0; d < 5000; d++)
+        ;
 }
 
 static inline bool waitSet(volatile uint32_t* reg, uint32_t mask)
@@ -72,8 +77,7 @@ static inline bool waitClear(volatile uint32_t* reg, uint32_t mask)
 
 static inline void i2cClearErrors(void)
 {
-    I2C1->ICR = I2C_ICR_NACKCF | I2C_ICR_STOPCF | I2C_ICR_BERRCF |
-                I2C_ICR_ARLOCF | I2C_ICR_OVRCF | I2C_ICR_PECCF |
+    I2C1->ICR = I2C_ICR_NACKCF | I2C_ICR_STOPCF | I2C_ICR_BERRCF | I2C_ICR_ARLOCF | I2C_ICR_OVRCF | I2C_ICR_PECCF |
                 I2C_ICR_TIMOUTCF | I2C_ICR_ALERTCF;
 }
 

--- a/STM32LowLevel/Lib/IMU/IMU.cpp
+++ b/STM32LowLevel/Lib/IMU/IMU.cpp
@@ -4,10 +4,53 @@
 #include <cstring>
 
 #include "stm32g4xx_ll_i2c.h"
+#include "stm32g4xx_ll_gpio.h"
 #include "stm32g4xx_hal.h"
 
-// Timeout in busy-wait loops (~10 ms at 170 MHz, 34000 loops/ms)
-static constexpr uint32_t I2C_TIMEOUT_LOOPS = 34000U * 10U;
+// Timeout in busy-wait loops (~10 ms at 170 MHz)
+static constexpr uint32_t I2C_TIMEOUT_LOOPS = 340000U;
+
+/**
+ * @brief Recover a stuck I2C bus by toggling SCL clock line.
+ *
+ * If SDA is held low by a device, we clock SCL to let the device
+ * finish its transfer. This is the standard I2C bus recovery procedure.
+ */
+static void i2cBusRecovery(void)
+{
+    // Configure PA15 (SCL) as GPIO output open-drain
+    LL_GPIO_SetPinMode(GPIOA, LL_GPIO_PIN_15, LL_GPIO_MODE_OUTPUT);
+    LL_GPIO_SetPinOutputType(GPIOA, LL_GPIO_PIN_15, LL_GPIO_OUTPUT_OPENDRAIN);
+    LL_GPIO_SetPinSpeed(GPIOA, LL_GPIO_PIN_15, LL_GPIO_SPEED_FREQ_HIGH);
+
+    // Toggle SCL up to 9 times to clock out any stuck device
+    for (int i = 0; i < 9; i++)
+    {
+        LL_GPIO_ResetOutputPin(GPIOA, LL_GPIO_PIN_15);
+        for (volatile uint32_t d = 0; d < 1000; d++);
+        LL_GPIO_SetOutputPin(GPIOA, LL_GPIO_PIN_15);
+        for (volatile uint32_t d = 0; d < 1000; d++);
+
+        // Check if SDA (PB7) has been released
+        if (LL_GPIO_IsInputPinSet(GPIOB, LL_GPIO_PIN_7))
+            break;
+    }
+
+    // Generate a STOP condition: SCL high, then SDA high
+    LL_GPIO_SetOutputPin(GPIOA, LL_GPIO_PIN_15);
+    for (volatile uint32_t d = 0; d < 1000; d++);
+    LL_GPIO_SetOutputPin(GPIOB, LL_GPIO_PIN_7);
+    for (volatile uint32_t d = 0; d < 1000; d++);
+
+    // Reconfigure PA15 back to I2C alternate function
+    LL_GPIO_SetPinMode(GPIOA, LL_GPIO_PIN_15, LL_GPIO_MODE_ALTERNATE);
+    LL_GPIO_SetPinOutputType(GPIOA, LL_GPIO_PIN_15, LL_GPIO_OUTPUT_OPENDRAIN);
+    LL_GPIO_SetPinSpeed(GPIOA, LL_GPIO_PIN_15, LL_GPIO_SPEED_FREQ_HIGH);
+    LL_GPIO_SetAFPin_0_7(GPIOA, LL_GPIO_PIN_15, LL_GPIO_AF_4);
+
+    // Small delay for bus to settle
+    for (volatile uint32_t d = 0; d < 5000; d++);
+}
 
 static inline bool waitSet(volatile uint32_t* reg, uint32_t mask)
 {
@@ -27,103 +70,159 @@ static inline bool waitClear(volatile uint32_t* reg, uint32_t mask)
     return true;
 }
 
-bool IMU::i2cWriteByte(uint8_t reg)
+static inline void i2cClearErrors(void)
+{
+    I2C1->ICR = I2C_ICR_NACKCF | I2C_ICR_STOPCF | I2C_ICR_BERRCF |
+                I2C_ICR_ARLOCF | I2C_ICR_OVRCF | I2C_ICR_PECCF |
+                I2C_ICR_TIMOUTCF | I2C_ICR_ALERTCF;
+}
+
+/**
+ * @brief Robust I2C write-then-read (repeated start).
+ * Mimics Arduino Wire: beginTransmission(addr); write(reg); endTransmission(false); requestFrom(addr, len);
+ * On any error, performs bus recovery.
+ */
+static bool i2cReadReg(uint8_t addr, uint8_t reg, uint8_t* buf, uint8_t len)
 {
     if (!waitClear(&I2C1->ISR, I2C_ISR_BUSY))
-        return false;
+    {
+        i2cBusRecovery();
+        if (!waitClear(&I2C1->ISR, I2C_ISR_BUSY))
+            return false;
+    }
+
+    i2cClearErrors();
+
+    // Phase 1: Write register address (SOFTEND = no STOP, repeated start follows)
     LL_I2C_HandleTransfer(I2C1,
-                          static_cast<uint32_t>(_addr) << 1U,
+                          static_cast<uint32_t>(addr) << 1U,
                           LL_I2C_ADDRSLAVE_7BIT,
                           1U,
                           LL_I2C_MODE_SOFTEND,
                           LL_I2C_GENERATE_START_WRITE);
+
     if (!waitSet(&I2C1->ISR, I2C_ISR_TXIS))
+    {
+        i2cBusRecovery();
         return false;
+    }
+
     if (I2C1->ISR & I2C_ISR_NACKF)
     {
         I2C1->ICR = I2C_ICR_NACKCF;
+        LL_I2C_GenerateStopCondition(I2C1);
+        waitSet(&I2C1->ISR, I2C_ISR_STOPF);
+        I2C1->ICR = I2C_ICR_STOPCF;
         return false;
     }
-    I2C1->TXDR = reg;
-    if (!waitSet(&I2C1->ISR, I2C_ISR_TC))
-        return false;
-    return true;
-}
 
-bool IMU::i2cReadBytes(uint8_t* buf, uint8_t len)
-{
+    I2C1->TXDR = reg;
+
+    if (!waitSet(&I2C1->ISR, I2C_ISR_TC))
+    {
+        i2cBusRecovery();
+        return false;
+    }
+
+    // Phase 2: Read data (AUTOEND = generates STOP after last byte)
     LL_I2C_HandleTransfer(I2C1,
-                          static_cast<uint32_t>(_addr) << 1U,
+                          static_cast<uint32_t>(addr) << 1U,
                           LL_I2C_ADDRSLAVE_7BIT,
                           len,
                           LL_I2C_MODE_AUTOEND,
                           LL_I2C_GENERATE_START_READ);
+
     for (uint8_t i = 0U; i < len; i++)
     {
         if (!waitSet(&I2C1->ISR, I2C_ISR_RXNE))
-            return false;
-        if (I2C1->ISR & I2C_ISR_NACKF)
         {
-            I2C1->ICR = I2C_ICR_NACKCF;
+            i2cBusRecovery();
             return false;
         }
         buf[i] = static_cast<uint8_t>(I2C1->RXDR);
     }
+
     if (!waitSet(&I2C1->ISR, I2C_ISR_STOPF))
+    {
+        i2cBusRecovery();
         return false;
+    }
+
     I2C1->ICR = I2C_ICR_STOPCF;
     return true;
 }
 
-bool IMU::i2cWriteRegByte(uint8_t reg, uint8_t val)
+/**
+ * @brief Robust I2C write register + value.
+ */
+static bool i2cWriteReg(uint8_t addr, uint8_t reg, uint8_t val)
 {
     if (!waitClear(&I2C1->ISR, I2C_ISR_BUSY))
-        return false;
+    {
+        i2cBusRecovery();
+        if (!waitClear(&I2C1->ISR, I2C_ISR_BUSY))
+            return false;
+    }
+
+    i2cClearErrors();
+
     LL_I2C_HandleTransfer(I2C1,
-                          static_cast<uint32_t>(_addr) << 1U,
+                          static_cast<uint32_t>(addr) << 1U,
                           LL_I2C_ADDRSLAVE_7BIT,
                           2U,
                           LL_I2C_MODE_AUTOEND,
                           LL_I2C_GENERATE_START_WRITE);
+
     if (!waitSet(&I2C1->ISR, I2C_ISR_TXIS))
+    {
+        i2cBusRecovery();
         return false;
+    }
+
     if (I2C1->ISR & I2C_ISR_NACKF)
     {
         I2C1->ICR = I2C_ICR_NACKCF;
+        LL_I2C_GenerateStopCondition(I2C1);
+        waitSet(&I2C1->ISR, I2C_ISR_STOPF);
+        I2C1->ICR = I2C_ICR_STOPCF;
         return false;
     }
+
     I2C1->TXDR = reg;
+
     if (!waitSet(&I2C1->ISR, I2C_ISR_TXIS))
-        return false;
-    if (I2C1->ISR & I2C_ISR_NACKF)
     {
-        I2C1->ICR = I2C_ICR_NACKCF;
+        i2cBusRecovery();
         return false;
     }
+
     I2C1->TXDR = val;
+
     if (!waitSet(&I2C1->ISR, I2C_ISR_STOPF))
+    {
+        i2cBusRecovery();
         return false;
+    }
+
     I2C1->ICR = I2C_ICR_STOPCF;
     return true;
 }
 
+// ======================== Public Methods ========================
+
 bool IMU::writeRegister(uint8_t reg, uint8_t value)
 {
-    return i2cWriteRegByte(reg, value);
+    return i2cWriteReg(_addr, reg, value);
 }
 
 bool IMU::readRegister(uint8_t reg, uint8_t& out)
 {
-    if (!i2cWriteByte(reg))
-        return false;
-    return i2cReadBytes(&out, 1U);
+    return i2cReadReg(_addr, reg, &out, 1U);
 }
 
 bool IMU::readRegisters(uint8_t reg, uint8_t* buffer, uint8_t length)
 {
-    if (!i2cWriteByte(reg))
-        return false;
-    return i2cReadBytes(buffer, length);
+    return i2cReadReg(_addr, reg, buffer, length);
 }
 
 void IMU::begin(uint8_t addr)
@@ -137,7 +236,7 @@ bool IMU::checkID()
     uint8_t id = 0;
     if (!readRegister(LSM6DSL_WHO_AM_I, id))
         return false;
-    return (id == 0x6AU);
+    return (id == _addr);
 }
 
 void IMU::enableAccel()

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -359,7 +359,7 @@ sudo apt install -y clang-format-19
 
 #### Verify Style Checks
 
-To verify that all files pass the style checks:
+To verify that all files pass the style checks on Linux/WSL:
 
 ```bash
 # Test that all files pass clang-format checks (same as GitHub workflow)
@@ -369,9 +369,14 @@ find Core/Src Lib USB_Device -name "*.cpp" -o -name "*.h" -o -name "*.tpp" | xar
 # If output shows errors, files need formatting
 ```
 
+On Windows:
+```powershell
+Get-ChildItem -Path Core/Src, Lib, USB_Device -Include *.cpp, *.h, *.tpp -Recurse | ForEach-Object { clang-format --dry-run --Werror -style=file $_.FullName }
+```
+
 #### Quick Auto-Fix (Recommended)
 
-To automatically fix all style issues in the project according to the style workflow:
+To automatically fix all style issues in the project according to the style workflow, run the following command on Linux/WSL:
 
 ```bash
 # Navigate to STM32LowLevel directory
@@ -379,6 +384,11 @@ cd STM32LowLevel
 
 # Format ALL files that are checked by the style workflow
 find Core/Src Lib USB_Device -name "*.cpp" -o -name "*.h" -o -name "*.tpp" | xargs clang-format-19 -i -style=file
+```
+
+On Windows:
+```powershell
+Get-ChildItem -Path Core/Src, Lib, USB_Device -Include *.cpp, *.h, *.tpp -Recurse | ForEach-Object { clang-format -i -style=file $_.FullName }
 ```
 
 #### Manual Check for Specific Files


### PR DESCRIPTION
The Encoder and IMU libraries experienced communication issues and bus contention due to the loose handling of the I2C communication. 

This update introduces debugging capabilities for I2C slave addresses and resolves the protocol handling issues.

Everything has been tested and will be merged immediately.