### PR TITLE
feat(led): add LED HP board PWM control

### DIFF
--- a/STM32LowLevel/Core/Src/main.cpp
+++ b/STM32LowLevel/Core/Src/main.cpp
@@ -194,6 +194,8 @@ static bool loadHomePositions(void);
 static bool saveHomePositions(void);
 static void tickBeakStateMachine(uint32_t now);
 #endif
+static void ledHpInit(void);
+static void ledHpSetBrightness(uint8_t brightness);
 #ifdef MODC_JOINT
 static void DXL_JOINT_INIT(void);
 #endif
@@ -366,6 +368,9 @@ extern "C" int main(void)
     // CAN — begin() releases STBY, so must come after MX_FDCAN2_Init()
     canW.begin();
     LOG_INFO("[main] CAN ready\n");
+
+    // LED HP board PWM init (TIM2_CH4 on PA3)
+    ledHpInit();
 
     // DXL bus init — DE pin direction and RX flush
     dxlBusInit(USART2);
@@ -976,6 +981,52 @@ static void tickBeakStateMachine(uint32_t now)
 }
 #endif // MODC_ARM
 
+/**
+ * Initialise LED HP board PWM control on TIM2_CH4 (PA3).
+ * PWM frequency ~10 kHz for flicker-free dimming.
+ */
+static void ledHpInit(void)
+{
+    // TIM2 is already configured by MX_TIM2_Init(), but the counter
+    // and CH4 output are not enabled. Fix the ARR and enable.
+
+    // Disable timer before reconfiguration
+    LL_TIM_DisableCounter(TIM2);
+
+    // Set ARR for ~10 kHz PWM: 170 MHz / 10000 = 17000
+    LL_TIM_SetAutoReload(TIM2, 16999U);
+
+    // Set initial duty cycle = 0 (off)
+    LL_TIM_OC_SetCompareCH4(TIM2, 0U);
+
+    // Enable CH4 output
+    LL_TIM_CC_EnableChannel(TIM2, LL_TIM_CHANNEL_CH4);
+
+    // Enable auto-reload preload
+    LL_TIM_EnableARRPreload(TIM2);
+
+    // Start counter
+    LL_TIM_EnableCounter(TIM2);
+
+    LOG_INFO("[LED_HP] PWM init: TIM2_CH4 PA3, ARR=%u\n", (unsigned)LL_TIM_GetAutoReload(TIM2));
+}
+
+/**
+ * Set LED HP board brightness.
+ * @param brightness 0 = off, 255 = max brightness
+ */
+static void ledHpSetBrightness(uint8_t brightness)
+{
+    // Map 0-255 to 0-ARR for linear brightness
+    // Inverted: the LED HP board enable is active-low through the N-FET stage,
+    // so 0% duty (compare=0) = LEDs ON, 100% duty (compare=ARR) = LEDs OFF.
+    uint32_t arr = LL_TIM_GetAutoReload(TIM2);
+    uint32_t compare = ((uint32_t)(255U - brightness) * arr) / 255U;
+    LL_TIM_OC_SetCompareCH4(TIM2, compare);
+
+    LOG_DEBUG("[LED_HP] brightness=%u compare=%u\n", brightness, (unsigned)compare);
+}
+
 #ifdef MODC_JOINT
 /**
  * Initialise all 3 joint Dynamixel motors on USART2.
@@ -1451,6 +1502,16 @@ static void handleSetpoint(uint8_t msgId, const uint8_t* msgData)
             jointMot2.setTorqueEnable((torqueBits & 0x0010U) != 0U);
 #endif
             LOG_INFO("[CAN] TORQUE_ENABLE_DISABLE: 0x%04X\n", torqueBits);
+            break;
+        }
+
+        // LED HP board brightness — all modules
+        case LED_HP_BRIGHTNESS:
+        {
+            uint8_t brightness;
+            memcpy(&brightness, msgData, 1U);
+            ledHpSetBrightness(brightness);
+            LOG_INFO("[CAN] LED_HP_BRIGHTNESS: %u\n", brightness);
             break;
         }
 

--- a/STM32LowLevel/Inc/communication.h
+++ b/STM32LowLevel/Inc/communication.h
@@ -62,6 +62,7 @@
 #define MOTOR_TRACTION_ERROR_STATUS 0x72  ///< Traction HW error bytes — uint8[2]: right, left
 #define MOTOR_ARM_ERROR_STATUS      0x73  ///< Arm HW error bytes     — uint8[7]: J1a…J6
 #define TORQUE_ENABLE_DISABLE       0x74  ///< Per-motor torque enable/disable  — uint16 bitfield (1=enable, 0=disable per bit)
+#define LED_HP_BRIGHTNESS           0x75  ///< LED HP board brightness  — uint8 (0=off, 255=max)
 
 // Arm velocity feedback — MK2 MOD1 only (0x8X)
 #define ARM_PITCH_1a1b_FEEDBACK_VEL 0x80  ///< Arm J1a/J1b velocity — Float×2, rad/s

--- a/tools/can_tester/cli.py
+++ b/tools/can_tester/cli.py
@@ -20,6 +20,7 @@ Commands:
     send reboot_arm                         Reboot arm motors
     send reboot_traction                    Reboot traction motors
     send torque <bitfield>                  Enable/disable per-motor torque (uint16 bitfield)
+    send led_hp <brightness>                 Set LED HP board brightness (0-255)
     stop                                    Emergency stop all motors
     monitor [filter]                        Start monitoring (filter: all|arm|traction|joint|feedback)
     test <name>                             Run test sequence (traction|arm_init|arm_joints|arm_beak|full)
@@ -203,6 +204,14 @@ class CLI:
             bitfield = int(args[1], 0)  # Auto-detect hex (0x) or decimal
             self.sender.torque_enable(bitfield, self.target)
             print(f"Torque enable/disable: bitfield=0x{bitfield:04X}")
+
+        elif subcmd == "led_hp" and len(args) == 2:
+            brightness = int(args[1])
+            if brightness < 0 or brightness > 255:
+                print("Usage: send led_hp <0-255>")
+                return
+            self.sender.led_hp_brightness(brightness, self.target)
+            print(f"LED HP brightness: {brightness}")
 
         elif subcmd == "joint_1a1b" and len(args) == 3:
             theta, phi = float(args[1]), float(args[2])

--- a/tools/can_tester/protocol.py
+++ b/tools/can_tester/protocol.py
@@ -93,6 +93,7 @@ class MsgType(IntEnum):
     MOTOR_TRACTION_ERROR_STATUS = 0x72
     MOTOR_ARM_ERROR_STATUS = 0x73
     TORQUE_ENABLE_DISABLE = 0x74
+    LED_HP_BRIGHTNESS = 0x75
 
     # Arm velocity feedback
     ARM_PITCH_1a1b_FEEDBACK_VEL = 0x80
@@ -219,6 +220,9 @@ PAYLOAD_FORMATS: dict[int, PayloadFormat] = {
 
     # Torque enable/disable — uint16 bitfield
     MsgType.TORQUE_ENABLE_DISABLE: PayloadFormat("<H", ["torque_bitfield"], "bits"),
+
+    # LED HP board brightness — uint8 (0=off, 255=max)
+    MsgType.LED_HP_BRIGHTNESS: PayloadFormat("<B", ["brightness"], "0-255"),
 
     # IMU raw data (debug)
     MsgType.IMU_RAW_ACCEL: PayloadFormat("<fff", ["ax", "ay", "az"], "g"),

--- a/tools/can_tester/sender.py
+++ b/tools/can_tester/sender.py
@@ -173,3 +173,16 @@ class CanSender:
             destination: Target module address.
         """
         self.send(MsgType.TORQUE_ENABLE_DISABLE, destination, torque_bitfield=torque_bitfield)
+
+    def led_hp_brightness(
+        self,
+        brightness: int,
+        destination: int = ModuleAddress.MK2_MOD1,
+    ) -> None:
+        """Set LED HP board brightness via PWM.
+
+        Args:
+            brightness: 0 (off) to 255 (max brightness).
+            destination: Target module address.
+        """
+        self.send(MsgType.LED_HP_BRIGHTNESS, destination, brightness=brightness)

--- a/tools/can_tester/web_dashboard.py
+++ b/tools/can_tester/web_dashboard.py
@@ -298,6 +298,9 @@ const CMDS_ARM = [
     { val: 'reboot_traction', label: 'Reboot Traction — Restart DC motors' },
     { val: 'stop_all', label: 'Emergency Stop — Zero all motors' },
   ]},
+  { group: 'LED', items: [
+    { val: 'led_hp', label: 'LED HP Board — Set brightness (0-255)' },
+  ]},
 ];
 
 const CMDS_JOINT = [
@@ -338,6 +341,8 @@ const CMD_INFO = {
   stop_all:   { desc: 'Emergency stop — sends zero speed to all traction motors on all modules.', lbl1: '', lbl2: '', inputs: 0, step: 1 },
   torque:     { desc: 'Enable or disable torque for a single motor.',
                  lbl1: 'Motor', lbl2: 'State', inputs: 'torque', step: 1 },
+  led_hp:     { desc: 'Set LED HP board brightness for search and rescue illumination.',
+                 lbl1: 'Brightness (0-255)', lbl2: '', inputs: 1, step: 16 },
   joint_1a1b: { desc: 'Set inter-module joint differential pitch/yaw. Theta controls yaw, phi controls pitch. Range: approx -1.57 to 1.57 rad.',
                  lbl1: 'Theta / Yaw (rad)', lbl2: 'Phi / Pitch (rad)', inputs: 2, step: 0.05 },
   joint_roll: { desc: 'Set inter-module joint axial roll. Range: approx -3.14 to 3.14 rad.',
@@ -858,6 +863,11 @@ def stream():
 
     def generate():
         try:
+            # Replay buffered messages from before client connected
+            with _msg_buffer_lock:
+                for msg in _msg_buffer:
+                    yield f"data: {json.dumps(msg)}\n\n"
+
             while True:
                 try:
                     data = q.get(timeout=30)
@@ -934,6 +944,10 @@ def send_command():
             # Accept hex (0x...) or decimal bitfield
             bitfield = int(data.get("val1", 0))
             sender.torque_enable(bitfield, destination=dest)
+        elif cmd == "led_hp":
+            brightness = int(data.get("val1", 0))
+            brightness = max(0, min(255, brightness))
+            sender.led_hp_brightness(brightness, destination=dest)
         elif cmd == "stop_all":
             sender.stop_all()
         else:


### PR DESCRIPTION
## What this adds

PWM dimming control for the LED HP board (3x LUXEON 2835 neutral-white LEDs) used for illumination. The board connects to J14 and is driven by TIM2_CH4 on PA3 through a 2N7002 N-FET.

## Changes

- Firmware: Added `ledHpInit()` and `ledHpSetBrightness()` functions, `LED_HP_BRIGHTNESS` CAN message type (0x75), and handler in `handleSetpoint`
- CAN tester: Added `led_hp_brightness` sender method, CLI command, protocol message type, and web dashboard UI

## Hardware

- LED driver: AL5802-7 constant-current, 65 mA
- Enable: 2N7002 N-FET gate controlled by PA3/TIM2_CH4
- PWM: ~10 kHz, inverted (active-low enable through N-FET stage)
